### PR TITLE
Change time to live for indexes

### DIFF
--- a/scripts/index/repo/index.js
+++ b/scripts/index/repo/index.js
@@ -8,7 +8,7 @@ const IndexOptimizer        = require("../../../services/indexer/index_optimizer
 const Logger                = require("../../../utils/logger");
 const elasticsearchAdapter  = require("../../../utils/search_adapters/elasticsearch_adapter");
 
-const DAYS_TO_KEEP = 7;
+const DAYS_TO_KEEP = process.env.DAYS_TO_KEEP || 2;
 const AGENCY_ENDPOINTS_FILE = path.join(__dirname, "../../../", config.AGENCY_ENDPOINTS_FILE);
 
 /**

--- a/scripts/index/term/index.js
+++ b/scripts/index/term/index.js
@@ -6,7 +6,7 @@ const IndexOptimizer        = require("../../../services/indexer/index_optimizer
 const Logger                = require("../../../utils/logger");
 const elasticsearchAdapter  = require("../../../utils/search_adapters/elasticsearch_adapter");
 
-const DAYS_TO_KEEP = 7;
+const DAYS_TO_KEEP = process.env.DAYS_TO_KEEP || 2;
 
 /**
  * Defines the class responsible for creating and managing the elasticsearch indexes


### PR DESCRIPTION
- Changed the time to live for ES indexes to get value from environment vars.
- Added a default time to live for ES indexes of 2 days. This should reduce the amount of space we are consuming.