### PR TITLE
Update codeclimate uploader

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - run:
           name: upload-test-report
           command: |
-             ./cc-test-reporter after-build -t lcov --exit-code $? build/coverage/lcov.info
+             ./cc-test-reporter after-build -t lcov -p ~/code-gov-api/build --exit-code $?
       - store_test_results:
           path: build/test-results/results.xml
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - run:
           name: upload-test-report
           command: |
-             ./cc-test-reporter after-build -t lcov -p ~/code-gov-api/build --exit-code $?
+             ./cc-test-reporter after-build -t lcov -p build/ --exit-code $?
       - store_test_results:
           path: build/test-results/results.xml
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,12 @@ jobs:
       - image: circleci/node:boron
     steps:
       - checkout
+      - run: 
+          name: download-cc-test-reporter
+          command: curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+      - run: 
+          name: make-test-reporter-executable
+          command: chmod +x ./cc-test-reporter
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
       - run:
@@ -14,7 +20,9 @@ jobs:
       - save_cache:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:
-              - ./node_modules
+            - ./node_modules
+      - run:
+          command: ./cc-test-reporter before-build
       - run:
           name: run-linter
           command: npm run lint
@@ -24,8 +32,7 @@ jobs:
       - run:
           name: upload-test-report
           command: |
-              npm install codeclimate-test-reporter
-              ./node_modules/.bin/codeclimate-test-reporter < build/coverage/lcov.info
+             ./cc-test-reporter after-build -t lcov --exit-code $? build/coverage/lcov.info
       - store_test_results:
           path: build/test-results/results.xml
       - store_artifacts:
@@ -48,7 +55,6 @@ jobs:
           command: |
             if [ "${CIRCLE_TAG}" =~ "${DEPLOY_TAG_PATTERN}" ]; then
               cf login -a ${CF_URL} -u ${CF_PRODUCTION_DEPLOYER} -p ${CF_PRODUCTION_DEPLOYER_PASS} -o ${CF_ORG} -s ${CF_PRODUCTION_SPACE}
-              cf target -o ${CF_ORG} -s ${CF_PRODUCTION_SPACE}
               cf push ${CF_APP}
             fi
 
@@ -57,6 +63,5 @@ jobs:
           command: |
             if [ "${CIRCLE_BRANCH}" == "${STAGING_DEPLOY_BRANCH}" ]; then
               cf login -a ${CF_URL} -u ${CF_STAGING_DEPLOYER} -p ${CF_STAGING_DEPLOYER_PASS} -o ${CF_ORG} -s ${CF_STAGING_SPACE}
-              cf target -o ${CF_ORG} -s ${CF_STAGING_SPACE}
               cf push ${CF_APP}
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - run:
           name: upload-test-report
           command: |
-             ./cc-test-reporter after-build -t lcov -p build/ --exit-code $?
+             ./cc-test-reporter after-build -t lcov -p /home/circleci/code-gov-api/build --exit-code $?
       - store_test_results:
           path: build/test-results/results.xml
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,14 +32,14 @@ jobs:
       - run:
           name: upload-test-report
           command: |
-             ./cc-test-reporter after-build -t lcov -p /home/circleci/code-gov-api/build --exit-code $?
+             ./cc-test-reporter after-build -t lcov --exit-code $?
       - store_test_results:
-          path: build/test-results/results.xml
+          path: test-results/results.xml
       - store_artifacts:
           path: test-results.xml
           prefix: tests
       - store_artifacts:
-          path: build/coverage
+          path: coverage
           prefix: coverage
       
       # Install Cloud Foundry cli (cf) before deploy step. cf is used to push project to Cloud.gov

--- a/.gitignore
+++ b/.gitignore
@@ -65,7 +65,6 @@ StatusDashboardScript
 /tmp
 .nyc_output
 .idea
-/build
 manifest_api_indexer.yml
 manifest_staging_api_indexer.yml
-
+test-results

--- a/.nycrc
+++ b/.nycrc
@@ -2,7 +2,7 @@
     "exclude": [
         "test/**/*.js"
     ],
-    "report-dir": "./build/coverage",
+    "report-dir": "./coverage",
     "reporter": [
         "lcov"
     ]

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,3 @@
 --reporter mocha-junit-reporter
 --recursive
---reporter-options mochaFile=./build/test-results/results.xml
+--reporter-options mochaFile=./test-results/results.xml


### PR DESCRIPTION
# Why

CodeClimate is deprecating the why test results and coverage is uploaded to their service. As such our CircleCI build config had to be updated to use the new tool. This was preventing coverage to be reported back to Github and thus didn't let us complete our Github checks.

# What changed

- Update CodeClimate coverage uploader - 2661c26
- Add prefix to coverage uploader - 55e3c19
- Fix prefix to coverage uploader - ecef3df
- Fix prefix to coverage uploader - 5ff54d1
- Add test-results gitignore - b0d0e91
- cc-test-reporter changes - d4c30bd
  - coverage directory is now created at the root of the project because cc-test-reporter does not accept paths and is garbage
  - test-results directory is now created at the root of the project because the build directory is no longer used because cc-test-reporter does not accept paths 
