### PR TITLE
Remove sonar-project.properties

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,0 @@
-sonar.projectKey=com.codegov.api
-sonar.projectName=Code.gov API Scanner-based project analyzed on SonarCloud using Travis
-sonar.projectVersion=1.0-SNAPSHOT
-sonar.sources=services


### PR DESCRIPTION
# Why
Sonar and Sonarcloud are not being used. It was replaced by Gemnasium.

# What changed

- Remove sonar-project.properties - 97bca12