### PR TITLE
Feature/update compliance report statuses

### DIFF
--- a/config/dev/agency_endpoints.json
+++ b/config/dev/agency_endpoints.json
@@ -5,7 +5,7 @@
   "website": "https://usda.gov/",
   "codeUrl": "/data/fallback/USDA.json",
   "requirements": {
-    "agencyWidePolicy": 0,
+    "agencyWidePolicy": 0.5,
     "openSourceRequirement":0,
     "inventoryRequirement":0
   }
@@ -16,7 +16,7 @@
   "website": "https://www.commerce.gov/",
   "codeUrl": "/data/fallback/DOC.json",
   "requirements": {
-    "agencyWidePolicy": 0,
+    "agencyWidePolicy": 0.5,
     "openSourceRequirement":0,
     "inventoryRequirement":0
   }
@@ -38,8 +38,8 @@
   "website": "https://ed.gov/",
   "codeUrl": "/data/fallback/ED.json",
   "requirements": {
-    "agencyWidePolicy": 0,
-    "openSourceRequirement":0,
+    "agencyWidePolicy": 1,
+    "openSourceRequirement":1,
     "inventoryRequirement":0
   }
 }, {
@@ -60,16 +60,17 @@
   "website": "https://hhs.gov",
   "codeUrl": "/data/fallback/HHS.json",
   "requirements": {
-    "agencyWidePolicy": 0,
+    "agencyWidePolicy": 1,
     "openSourceRequirement":0,
     "inventoryRequirement":0
   }
-}, {
-  "id": 29,
+},
+{
+  "id": 28,
   "name": "Department of Homeland Security",
   "acronym": "DHS",
-  "website": "https://dhs.gov",
-  "codeUrl": "https://dhs.gov/code.json",
+  "website": "https://www.dhs.gov",
+  "codeUrl": "/data/fallback/DHS.json",
   "requirements": {
     "agencyWidePolicy": 0,
     "openSourceRequirement":0,
@@ -82,7 +83,7 @@
   "website": "https://www.hud.gov/",
   "codeUrl": "/data/fallback/HUD.json",
   "requirements": {
-    "agencyWidePolicy": 0,
+    "agencyWidePolicy": 0.5,
     "openSourceRequirement":0,
     "inventoryRequirement":0
   }
@@ -104,7 +105,7 @@
   "website": "https://justice.gov",
   "codeUrl": "/data/fallback/DOJ.json",
   "requirements": {
-    "agencyWidePolicy": 0,
+    "agencyWidePolicy": 0.5,
     "openSourceRequirement":0,
     "inventoryRequirement":0
   }
@@ -115,7 +116,7 @@
   "website": "https://www.dol.gov",
   "codeUrl": "/data/fallback/DOL.json",
   "requirements": {
-    "agencyWidePolicy": 0,
+    "agencyWidePolicy": 1,
     "openSourceRequirement":0,
     "inventoryRequirement":0
   }
@@ -137,8 +138,8 @@
   "website": "https://www.transportation.gov/",
   "codeUrl": "/data/fallback/DOT.json",
   "requirements": {
-    "agencyWidePolicy": 0,
-    "openSourceRequirement":0,
+    "agencyWidePolicy": 1.0,
+    "openSourceRequirement":0.5,
     "inventoryRequirement":0
   }
 }, {
@@ -148,7 +149,7 @@
   "website": "https://www.treasury.gov/",
   "codeUrl": "/data/fallback/TRE.json",
   "requirements": {
-    "agencyWidePolicy": 0,
+    "agencyWidePolicy": 0.5,
     "openSourceRequirement":0,
     "inventoryRequirement":0
   }
@@ -170,8 +171,8 @@
   "website": "https://epa.gov/",
   "codeUrl": "/data/fallback/EPA.json",
   "requirements": {
-    "agencyWidePolicy": 0,
-    "openSourceRequirement":0,
+    "agencyWidePolicy": 0.5,
+    "openSourceRequirement":0.5,
     "inventoryRequirement":0
   }
 }, {
@@ -181,9 +182,9 @@
   "website": "https://nasa.gov/",
   "codeUrl": "/data/fallback/NASA.json",
   "requirements": {
-    "agencyWidePolicy": 0,
-    "openSourceRequirement":0,
-    "inventoryRequirement":0
+    "agencyWidePolicy": 1,
+    "openSourceRequirement":1,
+    "inventoryRequirement":0.5
   }
 }, {
   "id": 17,
@@ -192,9 +193,9 @@
   "website": "https://usaid.gov/",
   "codeUrl": "/data/fallback/AID.json",
   "requirements": {
-    "agencyWidePolicy": 0,
+    "agencyWidePolicy": 1,
     "openSourceRequirement":0,
-    "inventoryRequirement":0
+    "inventoryRequirement":0.5
   }
 }, {
   "id": 18,
@@ -203,9 +204,9 @@
   "website": "https://fema.gov/",
   "codeUrl": "/data/fallback/FEMA.json",
   "requirements": {
-    "agencyWidePolicy": 0,
-    "openSourceRequirement":0,
-    "inventoryRequirement":0
+    "agencyWidePolicy": null,
+    "openSourceRequirement":null,
+    "inventoryRequirement":null
   }
 }, {
   "id": 19,
@@ -215,8 +216,8 @@
   "codeUrl": "/data/fallback/GSA.json",
   "requirements": {
     "agencyWidePolicy": 1,
-    "openSourceRequirement":0,
-    "inventoryRequirement":0
+    "openSourceRequirement":1,
+    "inventoryRequirement":1
   }
 }, {
   "id": 20,
@@ -225,9 +226,9 @@
   "website": "https://nsf.gov/",
   "codeUrl": "/data/fallback/NSF.json",
   "requirements": {
-    "agencyWidePolicy": 0,
-    "openSourceRequirement":0,
-    "inventoryRequirement":0
+    "agencyWidePolicy": 1,
+    "openSourceRequirement":1,
+    "inventoryRequirement":1
   }
 }, {
   "id": 21,
@@ -236,9 +237,9 @@
   "website": "https://www.nrc.gov/",
   "codeUrl": "/data/fallback/NRC.json",
   "requirements": {
-    "agencyWidePolicy": 0,
+    "agencyWidePolicy": 0.5,
     "openSourceRequirement":0,
-    "inventoryRequirement":0
+    "inventoryRequirement":1
   }
 }, {
   "id": 22,
@@ -247,7 +248,7 @@
   "website": "https://opm.gov/",
   "codeUrl": "/data/fallback/OPM.json",
   "requirements": {
-    "agencyWidePolicy": 0,
+    "agencyWidePolicy": 0.5,
     "openSourceRequirement":0,
     "inventoryRequirement":0
   }
@@ -258,7 +259,7 @@
   "website": "https://sba.gov/",
   "codeUrl": "/data/fallback/SBA.json",
   "requirements": {
-    "agencyWidePolicy": 0,
+    "agencyWidePolicy": 1,
     "openSourceRequirement":0,
     "inventoryRequirement":0
   }
@@ -270,9 +271,9 @@
   "website": "https://archives.gov/",
   "codeUrl": "/data/fallback/NARA.json",
   "requirements": {
-    "agencyWidePolicy": 0,
-    "openSourceRequirement":0,
-    "inventoryRequirement":0
+    "agencyWidePolicy": null,
+    "openSourceRequirement": null,
+    "inventoryRequirement": null
   }
 },
 {
@@ -282,9 +283,9 @@
   "website": "https://consumerfinance.gov/",
   "codeUrl": "/data/fallback/CFPB.json",
   "requirements": {
-    "agencyWidePolicy": 0,
-    "openSourceRequirement":0,
-    "inventoryRequirement":0
+    "agencyWidePolicy": null,
+    "openSourceRequirement":null,
+    "inventoryRequirement":null
   }
 },
 {
@@ -294,20 +295,20 @@
   "website": "https://whitehouse.gov/",
   "codeUrl": "/data/fallback/EOP.json",
   "requirements": {
-    "agencyWidePolicy": 0,
-    "openSourceRequirement":0,
-    "inventoryRequirement":0
+    "agencyWidePolicy": null,
+    "openSourceRequirement":null,
+    "inventoryRequirement":null
   }
 },
 {
-  "id": 28,
-  "name": "Department of Homeland Security",
-  "acronym": "DHS",
-  "website": "https://www.dhs.gov",
-  "codeUrl": "/data/fallback/DHS.json",
+  "id": 27,
+  "name": "Social Security Administration",
+  "acronym": "SSA",
+  "website": "https://www.ssa.gov",
+  "codeUrl": "data/fallback/SSA.json",
   "requirements": {
-    "agencyWidePolicy": 0,
-    "openSourceRequirement":0,
-    "inventoryRequirement":0
+    "agencyWidePolicy": 1,
+    "openSourceRequirement":1,
+    "inventoryRequirement":0.5
   }
 }]

--- a/config/prod/agency_endpoints.json
+++ b/config/prod/agency_endpoints.json
@@ -8,7 +8,6 @@
     "agencyWidePolicy": 0.5,
     "openSourceRequirement":0,
     "inventoryRequirement":0
-    
   }
 }, {
   "id": 2,
@@ -17,7 +16,7 @@
   "website": "https://www.commerce.gov/",
   "codeUrl": "https://www.commerce.gov/code.json",
   "requirements": {
-    "agencyWidePolicy": 1,
+    "agencyWidePolicy": 0.5,
     "openSourceRequirement":0,
     "inventoryRequirement":0
   }
@@ -41,7 +40,7 @@
   "requirements": {
     "agencyWidePolicy": 1,
     "openSourceRequirement":1,
-    "inventoryRequirement":0.5
+    "inventoryRequirement":0
   }
 }, {
   "id": 5,
@@ -50,9 +49,9 @@
   "website": "https://energy.gov/",
   "codeUrl": "https://energy.gov/code.json",
   "requirements": {
-    "agencyWidePolicy": 0.5,
-    "openSourceRequirement":1,
-    "inventoryRequirement":0.5
+    "agencyWidePolicy": 0,
+    "openSourceRequirement":0,
+    "inventoryRequirement":0
   }
 }, {
   "id": 6,
@@ -62,7 +61,7 @@
   "codeUrl": "https://hhs.gov/code.json",
   "requirements": {
     "agencyWidePolicy": 1,
-    "openSourceRequirement":1,
+    "openSourceRequirement":0,
     "inventoryRequirement":0
   }
 }, {
@@ -74,7 +73,7 @@
   "requirements": {
     "agencyWidePolicy": 0.5,
     "openSourceRequirement":0,
-    "inventoryRequirement":1
+    "inventoryRequirement":0
   }
 }, 
 {
@@ -84,7 +83,7 @@
   "website": "https://dhs.gov",
   "codeUrl": "https://dhs.gov/code.json",
   "requirements": {
-    "agencyWidePolicy": 0.5,
+    "agencyWidePolicy": 0,
     "openSourceRequirement":0,
     "inventoryRequirement":0
   }
@@ -95,9 +94,9 @@
   "website": "https://data.doi.gov/",
   "codeUrl": "https://data.doi.gov/code.json",
   "requirements": {
-    "agencyWidePolicy": 0.5,
-    "openSourceRequirement":1,
-    "inventoryRequirement":1
+    "agencyWidePolicy": 0,
+    "openSourceRequirement":0,
+    "inventoryRequirement":0
   }
 }, {
   "id": 9,
@@ -128,7 +127,7 @@
   "website": "https://state.gov/",
   "codeUrl": "http://state.gov/code.json",
   "requirements": {
-    "agencyWidePolicy": 0.5,
+    "agencyWidePolicy": 0,
     "openSourceRequirement":0,
     "inventoryRequirement":0
   }
@@ -151,7 +150,7 @@
   "codeUrl": "https://www.treasury.gov/code.json",
   "requirements": {
     "agencyWidePolicy": 0.5,
-    "openSourceRequirement":1,
+    "openSourceRequirement":0,
     "inventoryRequirement":0
   }
 }, {
@@ -172,7 +171,7 @@
   "website": "https://epa.gov/",
   "codeUrl": "https://epa.gov/code.json",
   "requirements": {
-    "agencyWidePolicy": 0,
+    "agencyWidePolicy": 0.5,
     "openSourceRequirement":0.5,
     "inventoryRequirement":0
   }
@@ -218,7 +217,7 @@
   "requirements": {
     "agencyWidePolicy": 1,
     "openSourceRequirement":1,
-    "inventoryRequirement":0.5
+    "inventoryRequirement":1
   }
 }, {
   "id": 20,
@@ -238,8 +237,8 @@
   "website": "https://www.nrc.gov/",
   "codeUrl": "https://www.nrc.gov/code.json",
   "requirements": {
-    "agencyWidePolicy": 1,
-    "openSourceRequirement":1,
+    "agencyWidePolicy": 0.5,
+    "openSourceRequirement":0,
     "inventoryRequirement":1
   }
 }, {
@@ -271,9 +270,9 @@
   "website": "https://archives.gov/",
   "codeUrl": "https://archives.gov/code.json",
   "requirements": {
-    "agencyWidePolicy": 1,
-    "openSourceRequirement":0.5,
-    "inventoryRequirement":0.5
+    "agencyWidePolicy": null,
+    "openSourceRequirement": null,
+    "inventoryRequirement": null
   }
 },
 {
@@ -310,17 +309,5 @@
     "agencyWidePolicy": 1,
     "openSourceRequirement":1,
     "inventoryRequirement":0.5
-  }
-},
-{
-  "id": 28,
-  "name": "Department of Homeland Security",
-  "acronym": "DHS",
-  "website": "https://www.dhs.gov",
-  "codeUrl": "https://www.dhs.gov/code.json",
-  "requirements": {
-    "agencyWidePolicy": 0.5,
-    "openSourceRequirement":0,
-    "inventoryRequirement":0
   }
 }]

--- a/data/status/report.json
+++ b/data/status/report.json
@@ -1,22 +1,754 @@
 {
-  "timestamp": "Fri Sep 22 2017 10:59:26 GMT-0400 (EDT)",
+  "timestamp": "Wed Nov 08 2017 09:57:19 GMT-0500 (EST)",
   "statuses": {
     "USDA": {
-      "status": "FULLY COMPLIANT: 0 validation errors",
-      "issues": [],
-      "version": "1.0.1",
+      "status": "NOT FULLY COMPLIANT: 25 WARNINGS, 25 validation errors, 2 REQUESTED ENHANCEMENTS",
+      "issues": [
+        {
+          "repoID": "usda_ocio_digitalgov_analytics",
+          "agency": "Department of Agriculture",
+          "organization": "OCIO",
+          "project_name": "DigitalGov Analytics",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "usda_aphis_animal_disease_spread_model",
+          "agency": "Department of Agriculture",
+          "organization": "APHIS",
+          "project_name": "Animal Disease Spread Model",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "usda_usda_usda_apis",
+          "agency": "Department of Agriculture",
+          "organization": "USDA",
+          "project_name": "USDA-APIs",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "usda_usda_ridb",
+          "agency": "Department of Agriculture",
+          "organization": "USDA",
+          "project_name": "RIDB",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "usda_usda_data_standards",
+          "agency": "Department of Agriculture",
+          "organization": "USDA",
+          "project_name": "data-standards",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "usda_ars_argil_bovinetfbs",
+          "agency": "Department of Agriculture",
+          "organization": "ARS-ARGIL",
+          "project_name": "BovineTFBS",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "usda_ars_argil_cattlecnv",
+          "agency": "Department of Agriculture",
+          "organization": "ARS-ARGIL",
+          "project_name": "cattleCNV",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "type",
+                "dataPath": ".description",
+                "schemaPath": "#/properties/description/type",
+                "params": {
+                  "type": "string"
+                },
+                "message": "should be string"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "usda_ars_argil_cattlesd",
+          "agency": "Department of Agriculture",
+          "organization": "ARS-ARGIL",
+          "project_name": "cattleSD",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "type",
+                "dataPath": ".description",
+                "schemaPath": "#/properties/description/type",
+                "params": {
+                  "type": "string"
+                },
+                "message": "should be string"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "usda_ars_argil_alusite",
+          "agency": "Department of Agriculture",
+          "organization": "ARS-ARGIL",
+          "project_name": "Alusite",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "type",
+                "dataPath": ".description",
+                "schemaPath": "#/properties/description/type",
+                "params": {
+                  "type": "string"
+                },
+                "message": "should be string"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "usda_ars_argil_tfbsconssites",
+          "agency": "Department of Agriculture",
+          "organization": "ARS-ARGIL",
+          "project_name": "tfbsConsSites",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "type",
+                "dataPath": ".description",
+                "schemaPath": "#/properties/description/type",
+                "params": {
+                  "type": "string"
+                },
+                "message": "should be string"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "usda_ars_argil_divergence",
+          "agency": "Department of Agriculture",
+          "organization": "ARS-ARGIL",
+          "project_name": "divergence",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "type",
+                "dataPath": ".description",
+                "schemaPath": "#/properties/description/type",
+                "params": {
+                  "type": "string"
+                },
+                "message": "should be string"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "usda_ars_argil_bovinehapmap",
+          "agency": "Department of Agriculture",
+          "organization": "ARS-ARGIL",
+          "project_name": "BovineHapMap",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "type",
+                "dataPath": ".description",
+                "schemaPath": "#/properties/description/type",
+                "params": {
+                  "type": "string"
+                },
+                "message": "should be string"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "usda_ars_argil_usda_ars_agil_github_io",
+          "agency": "Department of Agriculture",
+          "organization": "ARS-ARGIL",
+          "project_name": "usda-ars-agil.github.io",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "type",
+                "dataPath": ".description",
+                "schemaPath": "#/properties/description/type",
+                "params": {
+                  "type": "string"
+                },
+                "message": "should be string"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "usda_ers_website_content_api",
+          "agency": "Department of Agriculture",
+          "organization": "ERS",
+          "project_name": "website-content-api",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "type",
+                "dataPath": ".description",
+                "schemaPath": "#/properties/description/type",
+                "params": {
+                  "type": "string"
+                },
+                "message": "should be string"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "usda_ers_widgets",
+          "agency": "Department of Agriculture",
+          "organization": "ERS",
+          "project_name": "widgets",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "usda_ers_data_apis",
+          "agency": "Department of Agriculture",
+          "organization": "ERS",
+          "project_name": "data-apis",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "usda_ers_geospatial_apis",
+          "agency": "Department of Agriculture",
+          "organization": "ERS",
+          "project_name": "geospatial-apis",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "type",
+                "dataPath": ".description",
+                "schemaPath": "#/properties/description/type",
+                "params": {
+                  "type": "string"
+                },
+                "message": "should be string"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "usda_fsa_fsa_style",
+          "agency": "Department of Agriculture",
+          "organization": "FSA",
+          "project_name": "fsa-style",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "usda_fsa_fsa_design_system",
+          "agency": "Department of Agriculture",
+          "organization": "FSA",
+          "project_name": "fsa-design-system",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "usda_fsa_fsa_design_system_draft_content",
+          "agency": "Department of Agriculture",
+          "organization": "FSA",
+          "project_name": "fsa-design-system-draft-content",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "usda_fsa_usda_fsa_github_io",
+          "agency": "Department of Agriculture",
+          "organization": "FSA",
+          "project_name": "usda-fsa.github.io",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "type",
+                "dataPath": ".description",
+                "schemaPath": "#/properties/description/type",
+                "params": {
+                  "type": "string"
+                },
+                "message": "should be string"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "usda_fsa_playbook_draft_content",
+          "agency": "Department of Agriculture",
+          "organization": "FSA",
+          "project_name": "playbook-draft-content",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "usda_vs_public",
+          "agency": "Department of Agriculture",
+          "organization": "VS",
+          "project_name": "public",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "usda_vs_reference_guided_assembly",
+          "agency": "Department of Agriculture",
+          "organization": "VS",
+          "project_name": "reference_guided_assembly",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "usda_vs_snp_analysis",
+          "agency": "Department of Agriculture",
+          "organization": "VS",
+          "project_name": "snp_analysis",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "usda_vs_playground",
+          "agency": "Department of Agriculture",
+          "organization": "VS",
+          "project_name": "playground",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "usda_vs_ksnp",
+          "agency": "Department of Agriculture",
+          "organization": "VS",
+          "project_name": "ksnp",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        }
+      ],
       "metadata": {
         "agency": {
           "name": "Department of Agriculture",
           "acronym": "USDA",
           "website": "https://usda.gov/",
-          "codeUrl": "https://www.usda.gov/code.json",
+          "codeUrl": "/data/fallback/USDA.json",
           "requirements": {
             "agencyWidePolicy": 0.5,
             "openSourceRequirement": 0,
             "inventoryRequirement": 0,
-            "schemaFormat": 1,
-            "overallCompliance": 0.375
+            "schemaFormat": 0.5,
+            "overallCompliance": 0
           }
         }
       },
@@ -24,12 +756,12 @@
         "agencyWidePolicy": 0.5,
         "openSourceRequirement": 0,
         "inventoryRequirement": 0,
-        "schemaFormat": 1,
-        "overallCompliance": 0.375
+        "schemaFormat": 0.5,
+        "overallCompliance": 0
       }
     },
     "DOC": {
-      "status": "FAILURE: ERROR WHEN FETCHING (Unexpected token < in JSON at position 0)",
+      "status": "FAILURE: MISSING PROJECTS FIELD",
       "issues": [],
       "version": "",
       "metadata": {
@@ -38,26 +770,26 @@
           "name": "Department of Commerce",
           "acronym": "DOC",
           "website": "https://www.commerce.gov/",
-          "codeUrl": "https://www.commerce.gov/code.json",
+          "codeUrl": "/data/fallback/DOC.json",
           "requirements": {
-            "agencyWidePolicy": 1,
+            "agencyWidePolicy": 0.5,
             "openSourceRequirement": 0,
             "inventoryRequirement": 0,
             "schemaFormat": 0,
-            "overallCompliance": 0.25
+            "overallCompliance": 0
           }
         }
       },
       "requirements": {
-        "agencyWidePolicy": 1,
+        "agencyWidePolicy": 0.5,
         "openSourceRequirement": 0,
         "inventoryRequirement": 0,
         "schemaFormat": 0,
-        "overallCompliance": 0.25
+        "overallCompliance": 0
       }
     },
     "DOD": {
-      "status": "FAILURE: ERROR WHEN FETCHING (Unexpected token < in JSON at position 0)",
+      "status": "FAILURE: MISSING PROJECTS FIELD",
       "issues": [],
       "version": "",
       "metadata": {
@@ -66,7 +798,7 @@
           "name": "Department of Defense",
           "acronym": "DOD",
           "website": "https://www.defense.gov/",
-          "codeUrl": "https://www.defense.gov/code.json",
+          "codeUrl": "/data/fallback/DOD.json",
           "requirements": {
             "agencyWidePolicy": 0,
             "openSourceRequirement": 0,
@@ -85,1115 +817,34 @@
       }
     },
     "ED": {
-      "status": "NOT FULLY COMPLIANT: 54 WARNINGS, 54 validation errors",
-      "issues": [
-        {
-          "repoID": "ed_oese_sharepoint_sites",
-          "agency": "Department of Education",
-          "project_name": "OESE SharePoint Sites",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_results_interstate_intrastate_coordination_website",
-          "agency": "Department of Education",
-          "project_name": "RESULTS: Interstate and Intrastate coordination website",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_migrant_student_information_exchange_msix_",
-          "agency": "Department of Education",
-          "project_name": "Migrant Student Information Exchange (MSIX)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_21st_cclc_program_professional_development_technical_assistance_portal",
-          "agency": "Department of Education",
-          "project_name": "21st CCLC Program - Professional Development and Technical Assistance Portal",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_ed_data_express",
-          "agency": "Department of Education",
-          "project_name": "ED Data Express",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_alternative_dispute_resolution_case_tracking_system_micropact_",
-          "agency": "Department of Education",
-          "project_name": "Alternative Dispute Resolution Case Tracking System (MicroPact)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_office_hearing_appeals_oha_case_tracking_and_reporting_system_micropact_",
-          "agency": "Department of Education",
-          "project_name": "Office of Hearing and Appeals (OHA) Case Tracking and Reporting System (MicroPact)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_parking_case_tracking_system_micropact_",
-          "agency": "Department of Education",
-          "project_name": "Parking Case Tracking System (MicroPact)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_federal_real_property_division_frpd_tracking_system_micropact_",
-          "agency": "Department of Education",
-          "project_name": "Federal Real Property Division (FRPD) Tracking System(MicroPact)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_labor_employee_relations_branch_case_tracking_system_micropact_",
-          "agency": "Department of Education",
-          "project_name": "Labor and Employee Relations Branch Case Tracking System (MicroPact)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_telework_agreement_form_workflow_sharepoint_",
-          "agency": "Department of Education",
-          "project_name": "Telework Agreement Form Workflow  (SharePoint)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_tuition_reimbursement_program_form_workflow_sharepoint_",
-          "agency": "Department of Education",
-          "project_name": "Tuition Reimbursement Program Form Workflow   (SharePoint)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_exit_clearance_form_workflow_sharepoint_",
-          "agency": "Department of Education",
-          "project_name": "Exit Clearance Form Workflow   (SharePoint)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_information_collection_request_review_approval_system_icras_",
-          "agency": "Department of Education",
-          "project_name": "Information Collection Request, Review, and Approval System (ICRAS)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_budget_formulation_database",
-          "agency": "Department of Education",
-          "project_name": "Budget Formulation Database",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_teacher_shortage_areas_nationwide_listing",
-          "agency": "Department of Education",
-          "project_name": "Teacher Shortage Areas Nationwide Listing",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_national_report_system_nrs_adult_ed_web_based_data_collection_warehousing",
-          "agency": "Department of Education",
-          "project_name": "National Report System (NRS) Adult Ed Web-Based Data Collection and Warehousing",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_literacy_information_communications_system",
-          "agency": "Department of Education",
-          "project_name": "Literacy Information and Communications System",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_financial_aid_toolkit",
-          "agency": "Department of Education",
-          "project_name": "Financial Aid Toolkit",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_adg_applications_adga_",
-          "agency": "Department of Education",
-          "project_name": "ADG Applications (ADGA)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_aid_data_mart_adm_",
-          "agency": "Department of Education",
-          "project_name": "Aid Data Mart (ADM)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_application_eligibility_determination_system_aeds_",
-          "agency": "Department of Education",
-          "project_name": "Application and Eligibility Determination System (AEDS)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_common_origination_disbursement_cod_",
-          "agency": "Department of Education",
-          "project_name": "Common Origination and Disbursement (COD)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_debt_management_collections_system_dmcs_",
-          "agency": "Department of Education",
-          "project_name": "Debt Management and Collections System (DMCS)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_ecampus_based_system",
-          "agency": "Department of Education",
-          "project_name": "eCampus Based System",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_edexpress",
-          "agency": "Department of Education",
-          "project_name": "EDExpress",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_enterprise_business_collaboration_ebc_",
-          "agency": "Department of Education",
-          "project_name": "Enterprise Business Collaboration (EBC)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_enterprise_data_warehouse_analytics_edwa_",
-          "agency": "Department of Education",
-          "project_name": "Enterprise Data Warehouse and Analytics (EDWA)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_enterprise_identity_management_service_eims_",
-          "agency": "Department of Education",
-          "project_name": "Enterprise Identity Management Service (EIMS)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_ez_audit",
-          "agency": "Department of Education",
-          "project_name": "eZ-Audit",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_federal_student_aid_financial_management_system_fsa_fms_",
-          "agency": "Department of Education",
-          "project_name": "Federal Student Aid Financial Management System (FSA FMS)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_fsa_portals_ifapandschoolsportion_",
-          "agency": "Department of Education",
-          "project_name": "FSA Portals (IFAPandSchoolsPortion)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_health_education_assistance_loans_heal_",
-          "agency": "Department of Education",
-          "project_name": "Health Education Assistance Loans (HEAL)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_integrated_partner_management_ipm_",
-          "agency": "Department of Education",
-          "project_name": "Integrated Partner Management (IPM)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_integrated_student_experience_ise_",
-          "agency": "Department of Education",
-          "project_name": "Integrated Student Experience (ISE)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_national_student_loan_database_system_nslds_",
-          "agency": "Department of Education",
-          "project_name": "National Student Loan Database System (NSLDS)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_ombudsman_case_tracking_system_coalition_federal_ombudsman_website_octs_",
-          "agency": "Department of Education",
-          "project_name": "Ombudsman Case Tracking System and Coalition of Federal Ombudsman Website (OCTS)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_postsecondary_education_participants_system_peps_",
-          "agency": "Department of Education",
-          "project_name": "Postsecondary Education Participants System (PEPS)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_student_aid_internet_gateway_saig_",
-          "agency": "Department of Education",
-          "project_name": "Student Aid Internet Gateway (SAIG)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_ed_web_support_services",
-          "agency": "Department of Education",
-          "project_name": "ED Web Support Services",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_open_source_search",
-          "agency": "Department of Education",
-          "project_name": "Open Source Search",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_cpss_contracts_purchasing_support_system",
-          "agency": "Department of Education",
-          "project_name": "CPSS � Contracts Purchasing and Support System",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_elvis_on_aem_s_server_",
-          "agency": "Department of Education",
-          "project_name": "ELVIS (on AEM's server)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_elvis_in_ies_data_center_",
-          "agency": "Department of Education",
-          "project_name": "ELVIS (in IES Data Center)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_eric_database",
-          "agency": "Department of Education",
-          "project_name": "ERIC Database",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_eric_processing_system",
-          "agency": "Department of Education",
-          "project_name": "ERIC Processing System",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_find_what_works",
-          "agency": "Department of Education",
-          "project_name": "Find What Works",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_reviewed_studies_database",
-          "agency": "Department of Education",
-          "project_name": "Reviewed Studies Database",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_online_courses",
-          "agency": "Department of Education",
-          "project_name": "Online Courses",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_online_study_review_guide",
-          "agency": "Department of Education",
-          "project_name": "Online Study Review Guide",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_rct_yes",
-          "agency": "Department of Education",
-          "project_name": "RCT Yes",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_edmaps",
-          "agency": "Department of Education",
-          "project_name": "EdMaps",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_program_outcomes_measures_targets_application_pomt_",
-          "agency": "Department of Education",
-          "project_name": "The Program, Outcomes, Measures and Targets Application (POMT)",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "ed_education_logic_model_elm_application",
-          "agency": "Department of Education",
-          "project_name": "The Education Logic Model (ELM) application",
-          "issues": {
-            "enhancements": [],
-            "warnings": [
-              {
-                "keyword": "format",
-                "dataPath": ".repository",
-                "schemaPath": "#/properties/repository/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "errors": []
-          }
-        }
-      ],
+      "status": "FULLY COMPLIANT: 0 validation errors",
+      "issues": [],
       "version": "1.0.1",
       "metadata": {
         "agency": {
           "name": "Department of Education",
           "acronym": "ED",
-          "website": "http://www.ed.gov/",
-          "codeUrl": "https://www2.ed.gov/code.json",
+          "website": "https://ed.gov/",
+          "codeUrl": "/data/fallback/ED.json",
           "requirements": {
             "agencyWidePolicy": 1,
             "openSourceRequirement": 1,
-            "inventoryRequirement": 0.5,
-            "schemaFormat": 0.5,
-            "overallCompliance": 0.75
+            "inventoryRequirement": 0,
+            "schemaFormat": 1,
+            "overallCompliance": 0.6666666666666666
           }
         }
       },
       "requirements": {
         "agencyWidePolicy": 1,
         "openSourceRequirement": 1,
-        "inventoryRequirement": 0.5,
-        "schemaFormat": 0.5,
-        "overallCompliance": 0.75
+        "inventoryRequirement": 0,
+        "schemaFormat": 1,
+        "overallCompliance": 0.6666666666666666
       }
     },
     "DOE": {
-      "status": "FAILURE: ERROR WHEN FETCHING (Unexpected token < in JSON at position 1)",
+      "status": "FAILURE: MISSING PROJECTS FIELD",
       "issues": [],
       "version": "",
       "metadata": {
@@ -1202,22 +853,22 @@
           "name": "Department of Energy",
           "acronym": "DOE",
           "website": "https://energy.gov/",
-          "codeUrl": "https://energy.gov/code.json",
+          "codeUrl": "/data/fallback/DOE.json",
           "requirements": {
-            "agencyWidePolicy": 0.5,
-            "openSourceRequirement": 1,
-            "inventoryRequirement": 0.5,
+            "agencyWidePolicy": 0,
+            "openSourceRequirement": 0,
+            "inventoryRequirement": 0,
             "schemaFormat": 0,
-            "overallCompliance": 0.5
+            "overallCompliance": 0
           }
         }
       },
       "requirements": {
-        "agencyWidePolicy": 0.5,
-        "openSourceRequirement": 1,
-        "inventoryRequirement": 0.5,
+        "agencyWidePolicy": 0,
+        "openSourceRequirement": 0,
+        "inventoryRequirement": 0,
         "schemaFormat": 0,
-        "overallCompliance": 0.5
+        "overallCompliance": 0
       }
     },
     "HHS": {
@@ -1229,22 +880,50 @@
           "name": "Department of Health and Human Services",
           "acronym": "HHS",
           "website": "https://hhs.gov",
-          "codeUrl": "https://hhs.gov/code.json",
+          "codeUrl": "/data/fallback/HHS.json",
           "requirements": {
             "agencyWidePolicy": 1,
-            "openSourceRequirement": 1,
+            "openSourceRequirement": 0,
             "inventoryRequirement": 0,
             "schemaFormat": 1,
-            "overallCompliance": 0.75
+            "overallCompliance": 0
           }
         }
       },
       "requirements": {
         "agencyWidePolicy": 1,
-        "openSourceRequirement": 1,
+        "openSourceRequirement": 0,
         "inventoryRequirement": 0,
         "schemaFormat": 1,
-        "overallCompliance": 0.75
+        "overallCompliance": 0
+      }
+    },
+    "DHS": {
+      "status": "FAILURE: MISSING PROJECTS FIELD",
+      "issues": [],
+      "version": "",
+      "metadata": {
+        "agency": {
+          "id": 28,
+          "name": "Department of Homeland Security",
+          "acronym": "DHS",
+          "website": "https://www.dhs.gov",
+          "codeUrl": "/data/fallback/DHS.json",
+          "requirements": {
+            "agencyWidePolicy": 0,
+            "openSourceRequirement": 0,
+            "inventoryRequirement": 0,
+            "schemaFormat": 0,
+            "overallCompliance": 0
+          }
+        }
+      },
+      "requirements": {
+        "agencyWidePolicy": 0,
+        "openSourceRequirement": 0,
+        "inventoryRequirement": 0,
+        "schemaFormat": 0,
+        "overallCompliance": 0
       }
     },
     "HUD": {
@@ -1255,40 +934,13 @@
           "name": "Department of Housing and Urban Development",
           "acronym": "HUD",
           "website": "https://www.hud.gov/",
-          "codeUrl": "https://www.hud.gov/code.json",
-          "requirements": {
-            "agencyWidePolicy": 0.5,
-            "openSourceRequirement": 0,
-            "inventoryRequirement": 1,
-            "schemaFormat": 1,
-            "overallCompliance": 0.625
-          }
-        }
-      },
-      "requirements": {
-        "agencyWidePolicy": 0.5,
-        "openSourceRequirement": 0,
-        "inventoryRequirement": 1,
-        "schemaFormat": 1,
-        "overallCompliance": 0.625
-      }
-    },
-    "DHS": {
-      "status": "FULLY COMPLIANT: 0 validation errors",
-      "issues": [],
-      "version": "1.0.1",
-      "metadata": {
-        "agency": {
-          "name": "Department of Homeland Security",
-          "acronym": "DHS",
-          "website": "https://www.dhs.gov",
-          "codeUrl": "https://www.dhs.gov/code.json",
+          "codeUrl": "/data/fallback/HUD.json",
           "requirements": {
             "agencyWidePolicy": 0.5,
             "openSourceRequirement": 0,
             "inventoryRequirement": 0,
             "schemaFormat": 1,
-            "overallCompliance": 0.375
+            "overallCompliance": 0
           }
         }
       },
@@ -1297,11 +949,11 @@
         "openSourceRequirement": 0,
         "inventoryRequirement": 0,
         "schemaFormat": 1,
-        "overallCompliance": 0.375
+        "overallCompliance": 0
       }
     },
     "DOI": {
-      "status": "FAILURE: ERROR WHEN FETCHING (unable to verify the first certificate)",
+      "status": "FAILURE: MISSING PROJECTS FIELD",
       "issues": [],
       "version": "",
       "metadata": {
@@ -1310,26 +962,26 @@
           "name": "Department of Interior",
           "acronym": "DOI",
           "website": "https://data.doi.gov/",
-          "codeUrl": "https://data.doi.gov/code.json",
+          "codeUrl": "/data/fallback/DOI.json",
           "requirements": {
-            "agencyWidePolicy": 0.5,
-            "openSourceRequirement": 1,
-            "inventoryRequirement": 1,
+            "agencyWidePolicy": 0,
+            "openSourceRequirement": 0,
+            "inventoryRequirement": 0,
             "schemaFormat": 0,
-            "overallCompliance": 0.625
+            "overallCompliance": 0
           }
         }
       },
       "requirements": {
-        "agencyWidePolicy": 0.5,
-        "openSourceRequirement": 1,
-        "inventoryRequirement": 1,
+        "agencyWidePolicy": 0,
+        "openSourceRequirement": 0,
+        "inventoryRequirement": 0,
         "schemaFormat": 0,
-        "overallCompliance": 0.625
+        "overallCompliance": 0
       }
     },
     "DOJ": {
-      "status": "FAILURE: ERROR WHEN FETCHING (Unexpected token < in JSON at position 0)",
+      "status": "FAILURE: MISSING PROJECTS FIELD",
       "issues": [],
       "version": "",
       "metadata": {
@@ -1338,13 +990,13 @@
           "name": "Department of Justice",
           "acronym": "DOJ",
           "website": "https://justice.gov",
-          "codeUrl": "https://justice.gov/code.json",
+          "codeUrl": "/data/fallback/DOJ.json",
           "requirements": {
             "agencyWidePolicy": 0.5,
             "openSourceRequirement": 0,
             "inventoryRequirement": 0,
             "schemaFormat": 0,
-            "overallCompliance": 0.125
+            "overallCompliance": 0
           }
         }
       },
@@ -1353,110 +1005,26 @@
         "openSourceRequirement": 0,
         "inventoryRequirement": 0,
         "schemaFormat": 0,
-        "overallCompliance": 0.125
+        "overallCompliance": 0
       }
     },
     "DOL": {
-      "status": "FULLY COMPLIANT: 0 validation errors, 4 REQUESTED ENHANCEMENTS",
-      "issues": [
-        {
-          "repoID": "dol_dol_department_developer",
-          "agency": "Department of Labor",
-          "organization": "DOL Department",
-          "project_name": "DEVELOPER",
-          "issues": {
-            "enhancements": [
-              {
-                "keyword": "format",
-                "dataPath": ".contact.email",
-                "schemaPath": "#/properties/contact/properties/email/format",
-                "params": {
-                  "format": "email"
-                },
-                "message": "should match format \"email\""
-              }
-            ],
-            "warnings": [],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "dol_dol_department_vets4212",
-          "agency": "Department of Labor",
-          "organization": "DOL Department",
-          "project_name": "VETS4212",
-          "issues": {
-            "enhancements": [
-              {
-                "keyword": "format",
-                "dataPath": ".contact.email",
-                "schemaPath": "#/properties/contact/properties/email/format",
-                "params": {
-                  "format": "email"
-                },
-                "message": "should match format \"email\""
-              }
-            ],
-            "warnings": [],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "dol_dol_department_doldatasdk_ios",
-          "agency": "Department of Labor",
-          "organization": "DOL Department",
-          "project_name": "DOLDATASDK IOS",
-          "issues": {
-            "enhancements": [
-              {
-                "keyword": "format",
-                "dataPath": ".downloadURL",
-                "schemaPath": "#/properties/downloadURL/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "warnings": [],
-            "errors": []
-          }
-        },
-        {
-          "repoID": "dol_dol_department_js_dashboard",
-          "agency": "Department of Labor",
-          "organization": "DOL Department",
-          "project_name": "JS DASHBOARD",
-          "issues": {
-            "enhancements": [
-              {
-                "keyword": "format",
-                "dataPath": ".license",
-                "schemaPath": "#/properties/license/format",
-                "params": {
-                  "format": "uri"
-                },
-                "message": "should match format \"uri\""
-              }
-            ],
-            "warnings": [],
-            "errors": []
-          }
-        }
-      ],
-      "version": "2.0.1",
+      "status": "FAILURE: MISSING PROJECTS FIELD",
+      "issues": [],
+      "version": "",
       "metadata": {
         "agency": {
+          "id": 10,
           "name": "Department of Labor",
           "acronym": "DOL",
           "website": "https://www.dol.gov",
-          "codeUrl": "https://www.dol.gov/code.json",
+          "codeUrl": "/data/fallback/DOL.json",
           "requirements": {
             "agencyWidePolicy": 1,
             "openSourceRequirement": 0,
             "inventoryRequirement": 0,
-            "schemaFormat": 1,
-            "overallCompliance": 0.5
+            "schemaFormat": 0,
+            "overallCompliance": 0
           }
         }
       },
@@ -1464,53 +1032,2973 @@
         "agencyWidePolicy": 1,
         "openSourceRequirement": 0,
         "inventoryRequirement": 0,
-        "schemaFormat": 1,
-        "overallCompliance": 0.5
+        "schemaFormat": 0,
+        "overallCompliance": 0
       }
     },
     "DOS": {
-      "status": "FULLY COMPLIANT: 0 validation errors",
-      "issues": [],
-      "version": "1.0.3",
-      "metadata": {
-        "agency": {
-          "name": "Department of State",
-          "acronym": "DOS",
-          "website": "https://state.gov/",
-          "codeUrl": "http://state.gov/code.json",
-          "requirements": {
-            "agencyWidePolicy": 0.5,
-            "openSourceRequirement": 0,
-            "inventoryRequirement": 0,
-            "schemaFormat": 1,
-            "overallCompliance": 0.375
-          }
-        }
-      },
-      "requirements": {
-        "agencyWidePolicy": 0.5,
-        "openSourceRequirement": 0,
-        "inventoryRequirement": 0,
-        "schemaFormat": 1,
-        "overallCompliance": 0.375
-      }
-    },
-    "DOT": {
       "status": "FAILURE: MISSING PROJECTS FIELD",
       "issues": [],
       "version": "",
       "metadata": {
         "agency": {
+          "id": 11,
+          "name": "Department of State",
+          "acronym": "DOS",
+          "website": "https://state.gov/",
+          "codeUrl": "/data/fallback/DOS.json",
+          "requirements": {
+            "agencyWidePolicy": 0,
+            "openSourceRequirement": 0,
+            "inventoryRequirement": 0,
+            "schemaFormat": 0,
+            "overallCompliance": 0
+          }
+        }
+      },
+      "requirements": {
+        "agencyWidePolicy": 0,
+        "openSourceRequirement": 0,
+        "inventoryRequirement": 0,
+        "schemaFormat": 0,
+        "overallCompliance": 0
+      }
+    },
+    "DOT": {
+      "status": "NOT FULLY COMPLIANT: 14 ERRORS, 82 WARNINGS, 96 validation errors",
+      "issues": [
+        {
+          "repoID": "dot_ost_ptbs_development",
+          "agency": "Department of Transportation",
+          "organization": "OST",
+          "project_name": "PTBS Development",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_ost_ptbs_test",
+          "agency": "Department of Transportation",
+          "organization": "OST",
+          "project_name": "PTBS Test",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_ost_ogc_c30",
+          "agency": "Department of Transportation",
+          "organization": "OST",
+          "project_name": "OGC-C30",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_ost_ost_ogc",
+          "agency": "Department of Transportation",
+          "organization": "OST",
+          "project_name": "OST - OGC",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_ost_ost_ogc",
+          "agency": "Department of Transportation",
+          "organization": "OST",
+          "project_name": "OST - OGC",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_ost_ost_ogc",
+          "agency": "Department of Transportation",
+          "organization": "OST",
+          "project_name": "OST - OGC",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_ost_ost_m20",
+          "agency": "Department of Transportation",
+          "organization": "OST",
+          "project_name": "OST - M20",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_ost_ost_s10_",
+          "agency": "Department of Transportation",
+          "organization": "OST",
+          "project_name": "OST S10 ",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_ost_bts_vista",
+          "agency": "Department of Transportation",
+          "organization": "OST",
+          "project_name": "BTS VISTA",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_ost_air_carrier_traffic_statistics",
+          "agency": "Department of Transportation",
+          "organization": "OST",
+          "project_name": "air_carrier_traffic_statistics",
+          "issues": {
+            "enhancements": [],
+            "warnings": [],
+            "errors": [
+              {
+                "keyword": "required",
+                "dataPath": "",
+                "schemaPath": "#/required",
+                "params": {
+                  "missingProperty": "repository"
+                },
+                "message": "should have required property 'repository'"
+              }
+            ]
+          }
+        },
+        {
+          "repoID": "dot_ost_air_travel_price_index",
+          "agency": "Department of Transportation",
+          "organization": "OST",
+          "project_name": "air_travel_price_index",
+          "issues": {
+            "enhancements": [],
+            "warnings": [],
+            "errors": [
+              {
+                "keyword": "required",
+                "dataPath": "",
+                "schemaPath": "#/required",
+                "params": {
+                  "missingProperty": "repository"
+                },
+                "message": "should have required property 'repository'"
+              }
+            ]
+          }
+        },
+        {
+          "repoID": "dot_ost_average_air_fares",
+          "agency": "Department of Transportation",
+          "organization": "OST",
+          "project_name": "average_air_fares",
+          "issues": {
+            "enhancements": [],
+            "warnings": [],
+            "errors": [
+              {
+                "keyword": "required",
+                "dataPath": "",
+                "schemaPath": "#/required",
+                "params": {
+                  "missingProperty": "repository"
+                },
+                "message": "should have required property 'repository'"
+              }
+            ]
+          }
+        },
+        {
+          "repoID": "dot_ost_bts_dictionary",
+          "agency": "Department of Transportation",
+          "organization": "OST",
+          "project_name": "bts_dictionary",
+          "issues": {
+            "enhancements": [],
+            "warnings": [],
+            "errors": [
+              {
+                "keyword": "required",
+                "dataPath": "",
+                "schemaPath": "#/required",
+                "params": {
+                  "missingProperty": "repository"
+                },
+                "message": "should have required property 'repository'"
+              }
+            ]
+          }
+        },
+        {
+          "repoID": "dot_ost_bulk_delete",
+          "agency": "Department of Transportation",
+          "organization": "OST",
+          "project_name": "bulk_delete",
+          "issues": {
+            "enhancements": [],
+            "warnings": [],
+            "errors": [
+              {
+                "keyword": "required",
+                "dataPath": "",
+                "schemaPath": "#/required",
+                "params": {
+                  "missingProperty": "repository"
+                },
+                "message": "should have required property 'repository'"
+              }
+            ]
+          }
+        },
+        {
+          "repoID": "dot_ost_major_pub",
+          "agency": "Department of Transportation",
+          "organization": "OST",
+          "project_name": "major_pub",
+          "issues": {
+            "enhancements": [],
+            "warnings": [],
+            "errors": [
+              {
+                "keyword": "required",
+                "dataPath": "",
+                "schemaPath": "#/required",
+                "params": {
+                  "missingProperty": "repository"
+                },
+                "message": "should have required property 'repository'"
+              }
+            ]
+          }
+        },
+        {
+          "repoID": "dot_ost_multi_import",
+          "agency": "Department of Transportation",
+          "organization": "OST",
+          "project_name": "multi_import",
+          "issues": {
+            "enhancements": [],
+            "warnings": [],
+            "errors": [
+              {
+                "keyword": "required",
+                "dataPath": "",
+                "schemaPath": "#/required",
+                "params": {
+                  "missingProperty": "repository"
+                },
+                "message": "should have required property 'repository'"
+              }
+            ]
+          }
+        },
+        {
+          "repoID": "dot_ost_recursive_import",
+          "agency": "Department of Transportation",
+          "organization": "OST",
+          "project_name": "recursive_import",
+          "issues": {
+            "enhancements": [],
+            "warnings": [],
+            "errors": [
+              {
+                "keyword": "required",
+                "dataPath": "",
+                "schemaPath": "#/required",
+                "params": {
+                  "missingProperty": "repository"
+                },
+                "message": "should have required property 'repository'"
+              }
+            ]
+          }
+        },
+        {
+          "repoID": "dot_ost_subject_areas",
+          "agency": "Department of Transportation",
+          "organization": "OST",
+          "project_name": "subject_areas",
+          "issues": {
+            "enhancements": [],
+            "warnings": [],
+            "errors": [
+              {
+                "keyword": "required",
+                "dataPath": "",
+                "schemaPath": "#/required",
+                "params": {
+                  "missingProperty": "repository"
+                },
+                "message": "should have required property 'repository'"
+              }
+            ]
+          }
+        },
+        {
+          "repoID": "dot_ost_subject_areas_wom",
+          "agency": "Department of Transportation",
+          "organization": "OST",
+          "project_name": "subject_areas_wom",
+          "issues": {
+            "enhancements": [],
+            "warnings": [],
+            "errors": [
+              {
+                "keyword": "required",
+                "dataPath": "",
+                "schemaPath": "#/required",
+                "params": {
+                  "missingProperty": "repository"
+                },
+                "message": "should have required property 'repository'"
+              }
+            ]
+          }
+        },
+        {
+          "repoID": "dot_ost_transportation_services_index",
+          "agency": "Department of Transportation",
+          "organization": "OST",
+          "project_name": "transportation_services_index",
+          "issues": {
+            "enhancements": [],
+            "warnings": [],
+            "errors": [
+              {
+                "keyword": "required",
+                "dataPath": "",
+                "schemaPath": "#/required",
+                "params": {
+                  "missingProperty": "repository"
+                },
+                "message": "should have required property 'repository'"
+              }
+            ]
+          }
+        },
+        {
+          "repoID": "dot_ost_custom_search",
+          "agency": "Department of Transportation",
+          "organization": "OST",
+          "project_name": "custom_search",
+          "issues": {
+            "enhancements": [],
+            "warnings": [],
+            "errors": [
+              {
+                "keyword": "required",
+                "dataPath": "",
+                "schemaPath": "#/required",
+                "params": {
+                  "missingProperty": "repository"
+                },
+                "message": "should have required property 'repository'"
+              }
+            ]
+          }
+        },
+        {
+          "repoID": "dot_ost_rita_book",
+          "agency": "Department of Transportation",
+          "organization": "OST",
+          "project_name": "rita_book",
+          "issues": {
+            "enhancements": [],
+            "warnings": [],
+            "errors": [
+              {
+                "keyword": "required",
+                "dataPath": "",
+                "schemaPath": "#/required",
+                "params": {
+                  "missingProperty": "repository"
+                },
+                "message": "should have required property 'repository'"
+              }
+            ]
+          }
+        },
+        {
+          "repoID": "dot_ost_addressfield_2abstate",
+          "agency": "Department of Transportation",
+          "organization": "OST",
+          "project_name": "addressfield_2abstate",
+          "issues": {
+            "enhancements": [],
+            "warnings": [],
+            "errors": [
+              {
+                "keyword": "required",
+                "dataPath": "",
+                "schemaPath": "#/required",
+                "params": {
+                  "missingProperty": "repository"
+                },
+                "message": "should have required property 'repository'"
+              }
+            ]
+          }
+        },
+        {
+          "repoID": "dot_ost_ost_prism",
+          "agency": "Department of Transportation",
+          "organization": "OST",
+          "project_name": "OST PRISM",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_fta_fta_coordinating_council_for_access_mobility_ccam_",
+          "agency": "Department of Transportation",
+          "organization": "FTA",
+          "project_name": "FTA Coordinating Council for Access & Mobility (CCAM) ",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_fta_fta_coordinating_council_for_access_mobility_ccam_",
+          "agency": "Department of Transportation",
+          "organization": "FTA",
+          "project_name": "FTA Coordinating Council for Access & Mobility (CCAM) ",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_fra_hos",
+          "agency": "Department of Transportation",
+          "organization": "FRA",
+          "project_name": "HOS",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_phmsa_ears",
+          "agency": "Department of Transportation",
+          "organization": "PHMSA",
+          "project_name": "EARS",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_phmsa_ears_mobile_app",
+          "agency": "Department of Transportation",
+          "organization": "PHMSA",
+          "project_name": "EARS Mobile App",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_phmsa_hip",
+          "agency": "Department of Transportation",
+          "organization": "PHMSA",
+          "project_name": "HIP",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_phmsa_online_cfr",
+          "agency": "Department of Transportation",
+          "organization": "PHMSA",
+          "project_name": "Online CFR",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_phmsa_m_v_approvals",
+          "agency": "Department of Transportation",
+          "organization": "PHMSA",
+          "project_name": "M-V Approvals",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_phmsa_special_permits",
+          "agency": "Department of Transportation",
+          "organization": "PHMSA",
+          "project_name": "Special Permits",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_phmsa_hazmat_registration",
+          "agency": "Department of Transportation",
+          "organization": "PHMSA",
+          "project_name": "Hazmat Registration",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_phmsa_pdm",
+          "agency": "Department of Transportation",
+          "organization": "PHMSA",
+          "project_name": "PDM",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_phmsa_smart",
+          "agency": "Department of Transportation",
+          "organization": "PHMSA",
+          "project_name": "SMART",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_phmsa_fim",
+          "agency": "Department of Transportation",
+          "organization": "PHMSA",
+          "project_name": "FIM",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_phmsa_phmsa_portal",
+          "agency": "Department of Transportation",
+          "organization": "PHMSA",
+          "project_name": "PHMSA Portal",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_phmsa_fedstar",
+          "agency": "Department of Transportation",
+          "organization": "PHMSA",
+          "project_name": "FedStar",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_phmsa_bank_america_import",
+          "agency": "Department of Transportation",
+          "organization": "PHMSA",
+          "project_name": "Bank of America Import",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_phmsa_hmis",
+          "agency": "Department of Transportation",
+          "organization": "PHMSA",
+          "project_name": "HMIS",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_phmsa_dot_approvals",
+          "agency": "Department of Transportation",
+          "organization": "PHMSA",
+          "project_name": "DOT Approvals",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_phmsa_annual_reports",
+          "agency": "Department of Transportation",
+          "organization": "PHMSA",
+          "project_name": "Annual Reports",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_phmsa_oms",
+          "agency": "Department of Transportation",
+          "organization": "PHMSA",
+          "project_name": "OMS",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_phmsa_npms",
+          "agency": "Department of Transportation",
+          "organization": "PHMSA",
+          "project_name": "NPMS",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_phmsa_pam",
+          "agency": "Department of Transportation",
+          "organization": "PHMSA",
+          "project_name": "PAM",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_phmsa_odes",
+          "agency": "Department of Transportation",
+          "organization": "PHMSA",
+          "project_name": "ODES",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_phmsa_registration_management",
+          "agency": "Department of Transportation",
+          "organization": "PHMSA",
+          "project_name": "Registration Management",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_nhtsa_geolocator",
+          "agency": "Department of Transportation",
+          "organization": "NHTSA",
+          "project_name": "Geolocator",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_nhtsa_vin_decoder",
+          "agency": "Department of Transportation",
+          "organization": "NHTSA",
+          "project_name": "VIN Decoder",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_nhtsa_parse",
+          "agency": "Department of Transportation",
+          "organization": "NHTSA",
+          "project_name": "PARSE",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_nhtsa_cissweb",
+          "agency": "Department of Transportation",
+          "organization": "NHTSA",
+          "project_name": "CISSWeb",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_nhtsa_toolbox",
+          "agency": "Department of Transportation",
+          "organization": "NHTSA",
+          "project_name": "Toolbox",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_nhtsa_helpdesk",
+          "agency": "Department of Transportation",
+          "organization": "NHTSA",
+          "project_name": "Helpdesk",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_nhtsa_upsa",
+          "agency": "Department of Transportation",
+          "organization": "NHTSA",
+          "project_name": "UPSA",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_nhtsa_variable_repository",
+          "agency": "Department of Transportation",
+          "organization": "NHTSA",
+          "project_name": "Variable Repository",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_nhtsa_mde",
+          "agency": "Department of Transportation",
+          "organization": "NHTSA",
+          "project_name": "MDE",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_nhtsa_intranet",
+          "agency": "Department of Transportation",
+          "organization": "NHTSA",
+          "project_name": "Intranet",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_nhtsa_query_tool",
+          "agency": "Department of Transportation",
+          "organization": "NHTSA",
+          "project_name": "Query Tool",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_nhtsa_sso",
+          "agency": "Department of Transportation",
+          "organization": "NHTSA",
+          "project_name": "SSO",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_nhtsa_edt_manager",
+          "agency": "Department of Transportation",
+          "organization": "NHTSA",
+          "project_name": "EDT Manager",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_nhtsa_case_viewer",
+          "agency": "Department of Transportation",
+          "organization": "NHTSA",
+          "project_name": "Case Viewer",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_nhtsa_fastfars",
+          "agency": "Department of Transportation",
+          "organization": "NHTSA",
+          "project_name": "FastFARS",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_nhtsa_report_builder",
+          "agency": "Department of Transportation",
+          "organization": "NHTSA",
+          "project_name": "Report Builder",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_nhtsa_edit_checks",
+          "agency": "Department of Transportation",
+          "organization": "NHTSA",
+          "project_name": "Edit Checks",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_nhtsa_irex",
+          "agency": "Department of Transportation",
+          "organization": "NHTSA",
+          "project_name": "iREx",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_nhtsa_naf",
+          "agency": "Department of Transportation",
+          "organization": "NHTSA",
+          "project_name": "NAF",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_nhtsa_mr_tool_sdag_",
+          "agency": "Department of Transportation",
+          "organization": "NHTSA",
+          "project_name": "MR Tool (SDAG)",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_nhtsa_travelontrack",
+          "agency": "Department of Transportation",
+          "organization": "NHTSA",
+          "project_name": "TravelOnTrack",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_nhtsa_sisame",
+          "agency": "Department of Transportation",
+          "organization": "NHTSA",
+          "project_name": "SISAME",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_nhtsa_vpic_list",
+          "agency": "Department of Transportation",
+          "organization": "NHTSA",
+          "project_name": "vPIC-List",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_nhtsa_encyclopedia",
+          "agency": "Department of Transportation",
+          "organization": "NHTSA",
+          "project_name": "Encyclopedia",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_nhtsa_cissform",
+          "agency": "Department of Transportation",
+          "organization": "NHTSA",
+          "project_name": "CISSForm",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_sls_n_a",
+          "agency": "Department of Transportation",
+          "organization": "SLS",
+          "project_name": "N/A",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_fhwa_dims",
+          "agency": "Department of Transportation",
+          "organization": "FHWA",
+          "project_name": "DIMS",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_fhwa_fois",
+          "agency": "Department of Transportation",
+          "organization": "FHWA",
+          "project_name": "FOIS",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_fhwa_fmis",
+          "agency": "Department of Transportation",
+          "organization": "FHWA",
+          "project_name": "FMIS",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_fhwa_fmis_5",
+          "agency": "Department of Transportation",
+          "organization": "FHWA",
+          "project_name": "FMIS-5",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_fhwa_foia",
+          "agency": "Department of Transportation",
+          "organization": "FHWA",
+          "project_name": "FOIA",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_fhwa_nbi",
+          "agency": "Department of Transportation",
+          "organization": "FHWA",
+          "project_name": "NBI",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_fhwa_nhi_cms",
+          "agency": "Department of Transportation",
+          "organization": "FHWA",
+          "project_name": "NHI/CMS",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_fhwa_rasps",
+          "agency": "Department of Transportation",
+          "organization": "FHWA",
+          "project_name": "RASPS",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_fhwa_tfics",
+          "agency": "Department of Transportation",
+          "organization": "FHWA",
+          "project_name": "TFICS",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_fhwa_upacs",
+          "agency": "Department of Transportation",
+          "organization": "FHWA",
+          "project_name": "UPACS",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_fhwa_nti",
+          "agency": "Department of Transportation",
+          "organization": "FHWA",
+          "project_name": "NTI",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_marad_n_a",
+          "agency": "Department of Transportation",
+          "organization": "MARAD",
+          "project_name": "N/A",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_oig_n_a",
+          "agency": "Department of Transportation",
+          "organization": "OIG",
+          "project_name": "N/A",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_fmsca_sfd",
+          "agency": "Department of Transportation",
+          "organization": "FMSCA",
+          "project_name": "SFD",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_fmsca_d_adb",
+          "agency": "Department of Transportation",
+          "organization": "FMSCA",
+          "project_name": "D&ADB",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_fmsca_erods",
+          "agency": "Department of Transportation",
+          "organization": "FMSCA",
+          "project_name": "eRODS",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_volpe_aviation_environmental_design_tool",
+          "agency": "Department of Transportation",
+          "organization": "VOLPE",
+          "project_name": "Aviation Environmental Design Tool",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_volpe_safetyhat",
+          "agency": "Department of Transportation",
+          "organization": "VOLPE",
+          "project_name": "SafetyHAT",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_faa_unmanned_aircraft_systems_registration_service_uasrs_",
+          "agency": "Department of Transportation",
+          "organization": "FAA",
+          "project_name": "Unmanned Aircraft Systems Registration Service (UASRS)",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_faa_b4ufly",
+          "agency": "Department of Transportation",
+          "organization": "FAA",
+          "project_name": "B4UFly",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_faa_edai",
+          "agency": "Department of Transportation",
+          "organization": "FAA",
+          "project_name": "EDAI",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "dot_faa_edcs",
+          "agency": "Department of Transportation",
+          "organization": "FAA",
+          "project_name": "EDCS",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "enum",
+                "dataPath": ".status",
+                "schemaPath": "#/properties/status/enum",
+                "params": {
+                  "allowedValues": [
+                    "Ideation",
+                    "Alpha",
+                    "Beta",
+                    "Production",
+                    "Archival",
+                    "ideation",
+                    "alpha",
+                    "beta",
+                    "production",
+                    "archival"
+                  ]
+                },
+                "message": "should be equal to one of the allowed values"
+              }
+            ],
+            "errors": []
+          }
+        }
+      ],
+      "version": "1.0.1",
+      "metadata": {
+        "agency": {
           "name": "Department of Transportation",
           "acronym": "DOT",
           "website": "https://www.transportation.gov/",
-          "codeUrl": "https://www.transportation.gov/code.json",
+          "codeUrl": "/data/fallback/DOT.json",
           "requirements": {
             "agencyWidePolicy": 1,
             "openSourceRequirement": 0.5,
             "inventoryRequirement": 0,
-            "schemaFormat": 0,
-            "overallCompliance": 0.375
+            "schemaFormat": 0.5,
+            "overallCompliance": 0.5
           }
         }
       },
@@ -1518,39 +4006,40 @@
         "agencyWidePolicy": 1,
         "openSourceRequirement": 0.5,
         "inventoryRequirement": 0,
-        "schemaFormat": 0,
-        "overallCompliance": 0.375
+        "schemaFormat": 0.5,
+        "overallCompliance": 0.5
       }
     },
     "TRE": {
-      "status": "FULLY COMPLIANT: 0 validation errors",
+      "status": "FAILURE: MISSING PROJECTS FIELD",
       "issues": [],
-      "version": "1.0.1",
+      "version": "",
       "metadata": {
         "agency": {
+          "id": 13,
           "name": "Department of Treasury",
           "acronym": "TRE",
           "website": "https://www.treasury.gov/",
-          "codeUrl": "https://www.treasury.gov/code.json",
+          "codeUrl": "/data/fallback/TRE.json",
           "requirements": {
             "agencyWidePolicy": 0.5,
-            "openSourceRequirement": 1,
+            "openSourceRequirement": 0,
             "inventoryRequirement": 0,
-            "schemaFormat": 1,
-            "overallCompliance": 0.625
+            "schemaFormat": 0,
+            "overallCompliance": 0
           }
         }
       },
       "requirements": {
         "agencyWidePolicy": 0.5,
-        "openSourceRequirement": 1,
+        "openSourceRequirement": 0,
         "inventoryRequirement": 0,
-        "schemaFormat": 1,
-        "overallCompliance": 0.625
+        "schemaFormat": 0,
+        "overallCompliance": 0
       }
     },
     "VA": {
-      "status": "FAILURE: ERROR WHEN FETCHING (Unexpected token < in JSON at position 0)",
+      "status": "FAILURE: MISSING PROJECTS FIELD",
       "issues": [],
       "version": "",
       "metadata": {
@@ -1559,7 +4048,7 @@
           "name": "Department of Veterans Affairs",
           "acronym": "VA",
           "website": "https://va.gov/",
-          "codeUrl": "https://va.gov/code.json",
+          "codeUrl": "/data/fallback/VA.json",
           "requirements": {
             "agencyWidePolicy": 0,
             "openSourceRequirement": 0,
@@ -1578,48 +4067,4334 @@
       }
     },
     "EPA": {
-      "status": "FULLY COMPLIANT: 0 validation errors",
+      "status": "FAILURE: MISSING PROJECTS FIELD",
       "issues": [],
-      "version": "1.0.1",
+      "version": "",
       "metadata": {
         "agency": {
+          "id": 15,
           "name": "Environmental Protection Agency",
           "acronym": "EPA",
           "website": "https://epa.gov/",
-          "codeUrl": "https://epa.gov/code.json",
+          "codeUrl": "/data/fallback/EPA.json",
           "requirements": {
-            "agencyWidePolicy": 0,
+            "agencyWidePolicy": 0.5,
             "openSourceRequirement": 0.5,
             "inventoryRequirement": 0,
-            "schemaFormat": 1,
-            "overallCompliance": 0.375
+            "schemaFormat": 0,
+            "overallCompliance": 0.3333333333333333
           }
         }
       },
       "requirements": {
-        "agencyWidePolicy": 0,
+        "agencyWidePolicy": 0.5,
         "openSourceRequirement": 0.5,
         "inventoryRequirement": 0,
-        "schemaFormat": 1,
-        "overallCompliance": 0.375
+        "schemaFormat": 0,
+        "overallCompliance": 0.3333333333333333
       }
     },
     "NASA": {
-      "status": "FULLY COMPLIANT: 0 validation errors",
-      "issues": [],
+      "status": "NOT FULLY COMPLIANT: 34 WARNINGS, 34 validation errors, 170 REQUESTED ENHANCEMENTS",
+      "issues": [
+        {
+          "repoID": "nasa_arc_nasa_tensegrity_robotics_toolkit_ntrt_v1",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "NASA Tensegrity Robotics Toolkit (NTRT) v1",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_code_a_software_framework_for_control_observation_in_distributed_environments",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "CODE-A Software Framework For Control and Observation In Distributed Environments",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_livingstone_2_system_for_automated_diagnosis_discrete_control_complex_systems_and_skunkworks_suite_of_supporting_development_and_runtime_tools_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Livingstone 2 (System for Automated Diagnosis and Discrete Control of Complex Systems) and Skunkworks (Suite of Supporting Development and Runtime Tools)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_mission_simulation_toolkit_mst_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Mission Simulation Toolkit (MST)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_java_pathfinder_jpf_version_2_0",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Java Pathfinder (JPF), Version 2.0",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_captools_based_automatic_parallelizer_using_openmp_capo_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "CAPTools-based Automatic Parallelizer Using OpenMP (CAPO)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_sound_lab_slab_version_5",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Sound Lab (SLAB), Version 5",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_viewpoints_software_for_visualization_multivariate_data",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Viewpoints: Software for Visualization of Multivariate Data",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_libibvpp",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Libibvpp",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_mariana_text_classification_system",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Mariana: Text Classification System",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_geometry_manipulation_protocol_gmp_for_computationalfluid_dynamics_cfd_applications_version_1_0",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Geometry Manipulation Protocol (GMP) for ComputationalFluid Dynamics (CFD) Applications, Version 1.0",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_sequenceminer_anomaly_detection_in_large_sets_high_dimensional_symbol_sequences",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "SequenceMiner-Anomaly Detection in Large Sets of High-Dimensional Symbol Sequences",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_constellation_praca_extension_bugzilla_application",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Constellation PRACA Extension of the Bugzilla Application",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_nu_anomica_previously_sparse_one_class_support_vector_machines_soc_svms_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "nu-Anomica (Previously Sparse One Class Support Vector Machines (SOC-SVMs))",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_highly_scalable_matching_pursuit_signal_decomposition_algorithm_mpd_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Highly Scalable Matching Pursuit Signal Decomposition Algorithm (MPD)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_parallel_dantzig_wolfe_decomposition",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Parallel Dantzig-Wolfe Decomposition",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_multiple_kernel_anomaly_detection_mkad_algorithm",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Multiple Kernel Anomaly Detection (MKAD) Algorithm",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_autobayes_automatic_design_customized_analysis_algorithms_programs",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "AutoBayes: Automatic Design of Customized Analysis Algorithms and Programs",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_autonomous_explorer_control_system_axcs_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Autonomous eXplorer Control System (AXCS)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_visual_environment_for_remote_virtual_exploration_verve_version_2",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Visual Environment for Remote Virtual Exploration (VERVE), Version 2",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_network_form_game_software_library_libnfg_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Network-Form Game Software Library (libnfg)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_kepler_community_data_analysis_tools_pyke_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Kepler Community Data Analysis Tools (PyKE)",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_neo_geography_toolkit_ngt_version_2",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Neo-Geography Toolkit (NGT), Version 2",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_nasa_vision_workbench_vw_version_3",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "NASA Vision Workbench (VW), Version 3",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_inference_kernel_for_open_static_ikos_analyzers_a_high_performance_static_analysis_engine_to_build_automated_code_analysis_tools_for_formal_verification_critical_software_properties",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Inference Kernel for Open Static (IKOS) Analyzers: A High-Performance Static Analysis Engine to Build Automated Code Analysis Tools for the Formal Verification of Critical Software Properties",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_robot_application_programming_interface_delegate_rapid_version_2",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Robot Application Programming Interface Delegate (RAPID), Version 2",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_physics_model_based_wiring_fault_detection_toolbox_for_matlab",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Physics-Model-Based Wiring Fault Detection Toolbox for MATLAB",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_computational_fluid_dynamics_cfd_utility_software_library",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Computational Fluid Dynamics (CFD) Utility Software Library",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_open_scheduling_planning_interface_for_exploration_openspife_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Open Scheduling and Planning Interface for Exploration (OpenSPIFe)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_multi_threaded_copy_program_mcp_aka_mutil",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Multi-threaded Copy Program (MCP) aka Mutil",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_netmark_extensible_database_data_access_retrieval_composition_xdb3_darc_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Netmark eXtensible DataBase, Data Access and Retrieval Composition (XDB3-DARC)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_pathdroid",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "PathDroid",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_crisis_mapping_toolkit_cmt_v1",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Crisis Mapping Toolkit (CMT) v1",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_scalable_gaussian_process_regression",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Scalable Gaussian Process Regression",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_ind_2_1_creation_manipulation_decision_trees_from_data",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "IND 2.1-Creation and Manipulation of Decision Trees from Data",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_java_pathfinder_jpf_core_system",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Java Pathfinder (JPF) core system",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_jpf_nas_an_extension_java_pathfinder_that_provides_support_for_model_checking_distributed_systems",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "JPF-NAS, an extension of Java Pathfinder that provides support for model checking distributed systems",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_mfsim_multi_fidelity_simulation",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "MFSim - Multi-fidelity Simulation",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_multivariate_time_series_search_capability_to_identify_complex_patterns_in_large_datasets",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Multivariate Time Series Search Capability to Identify Complex Patterns in Large Datasets",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_portable_environment_for_quick_image_processing_quip_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Portable Environment for Quick Image Processing (QuIP)",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_extendable_uniform_remote_operations_planning_architecture_europa_2_1",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Extendable Uniform Remote Operations Planning Architecture (EUROPA) 2.1",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_race_runtime_for_airspace_concept_evaluation",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "RACE - Runtime for Airspace Concept Evaluation",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_surfer_an_extensible_pull_based_framework_for_resource_selection_ranking",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Surfer: An Extensible Pull-Based Framework For Resource Selection and Ranking",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_pour_a_framework_for_periodic_on_demand_user_specified_information_reconciliation",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Pour: A Framework for Periodic, On-Demand, and User-Specified Information Reconciliation",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_swim_a_software_information_metacatalog_for_grid",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Swim: A Software Information Metacatalog for the Grid",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_ballast_balancing_load_across_systems",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Ballast: Balancing Load Across Systems",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_dyper_dynamic_perimeter_enforcement",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Dyper: Dynamic Perimeter Enforcement",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_synchronization_archival_validation_ip_exchange_save_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Synchronization, Archival, Validation, and IP Exchange (Save)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_savors_a_scalable_aural_visual_environment_for_security_event_monitoring_analysis_response",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Savors: A Scalable Aural-Visual Environment for Security Event Monitoring, Analysis, And Response",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_world_wind_java_virtual_globe_software_development_kit_sdk_world_wind_android_virtual_globe_software_development_kit_sdk_web_world_wind_virtual_globe_software_development_kit_sdk_world_wind_ios_virtual_globe_software_development_kit_sdk_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "World Wind Java Virtual Globe Software Development Kit (SDK)\r\nWorld Wind Android Virtual Globe Software Development Kit (SDK)\r\nWeb World Wind Virtual Globe Software Development Kit (SDK)\r\nWorld Wind iOS Virtual Globe Software Development Kit (SDK)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_javagenes_scheduler_evolutionary_software_for_earth_observing_satellite_scheduling",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "JavaGenes-Scheduler: Evolutionary Software for Earth Observing Satellite Scheduling",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_javagenes_genetic_graphs",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "JavaGenes Genetic Graphs",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_geocam_version_2",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "GeoCam, Version 2",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_x_plane_communication_toolbox_xpc_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "X-Plane Communication Toolbox (XPC)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_open_mission_control_technologies_open_mct_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Open Mission Control Technologies (Open MCT)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_desktop_exploration_remote_terrain_dert_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Desktop Exploration of Remote Terrain (DERT)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_prognostics_algorithm_library",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Prognostics Algorithm Library",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_arc_prognostics_model_library",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "ARC",
+          "project_name": "Prognostics Model Library",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_dfrc_blackbody_vba_excel_functions",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "DFRC",
+          "project_name": "Blackbody VBA Excel Functions",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_dfrc_ezase_easy_aeroservoelasticity",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "DFRC",
+          "project_name": "EZASE  Easy Aeroservoelasticity",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_grc_toolbox_for_modeling_analysis_thermodynamic_systems_t_mats_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GRC",
+          "project_name": "Toolbox for the Modeling and Analysis of Thermodynamic Systems (T-MATS)",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_grc_tool_for_turbine_engine_closed_loop_transient_analysis_ttectra_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GRC",
+          "project_name": "Tool for Turbine Engine Closed-loop Transient Analysis (TTECTrA)",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_grc_nasa_glenn_research_center_early_years_for_ipad",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GRC",
+          "project_name": "NASA Glenn Research Center: The Early Years for iPad",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_grc_nasa_flywheel_for_ipad",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GRC",
+          "project_name": "NASA Flywheel for iPad",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_grc_eadin_communication_protocol",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GRC",
+          "project_name": "EADIN Communication Protocol",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_grc_channel_emulator",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GRC",
+          "project_name": "Channel Emulator",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_grc_open_mdao_version_0_1_next_generation_multidisciplinary_design_analysis_optimization_mdao_open_source_framework",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GRC",
+          "project_name": "Open MDAO Version 0.1: The Next Generation Multidisciplinary Design Analysis and Optimization (MDAO) Open Source Framework",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_grc_ipv6_python_extension_module",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GRC",
+          "project_name": "IPv6 Python Extension Module",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_grc_ccgeom",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GRC",
+          "project_name": "CCGEOM",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_grc_pycycle_an_cycle_modeling_tool_for_design_with_gradient_based_optimization",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GRC",
+          "project_name": "PyCycle - An Cycle Modeling Tool For Design With Gradient Based Optimization",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_java_astrodynamics_toolkit_jat_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Java Astrodynamics Toolkit (JAT)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_hierarchical_data_format_earth_observing_system_hdf_eos_data_extractor_heex_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Hierarchical Data Format Earth Observing System (HDF-EOS)Data Extractor (HEEX)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_parallel_adaptive_mesh_refinement_library_paramesh_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Parallel Adaptive Mesh Refinement Library (PARAMESH)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_advanced_limage_assessment_system_alias_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Advanced Land Image Assessment System (ALIAS)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_tool_for_interactive_plotting_sonification_3d_orbit_display_tipsod_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Tool For Interactive Plotting, Sonification, and 3D Orbit Display (TIPSOD)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_matlab_zemax_toolkit",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "MATLAB-Zemax Toolkit",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_coordinated_data_analysis_workshop_web_cdaweb_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Coordinated Data Analysis Workshop Web (CDAWeb)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_space_physics_data_facility_spdf_web_services",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Space Physics Data Facility (SPDF) Web Services",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_earth_observing_system_eos_clearing_house_echo_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Earth Observing System (EOS) Clearing House (ECHO)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_general_eqflux",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "General EQFlux",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_earth_observing_system_eos_data_gateway_edg_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Earth Observing System (EOS) Data Gateway (EDG)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_operating_system_abstraction_layer_osal_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Operating System Abstraction Layer (OSAL)",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_architecture_adaptive_computing_environment_ace_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Architecture Adaptive Computing Environment (ACE)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_simple_scalable_script_based_science_processor_for_missions_s4pm_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Simple, Scalable, Script-Based Science Processor for Missions (S4PM)",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_xml_to_hdf_eos_convertor",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "XML to HDF-EOS Convertor",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_hdfview_plugin",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "HDFView Plugin",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_interoperable_remote_component_irc_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Interoperable Remote Component (IRC)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_nasa_rb_formerly_funit_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "NASA.rb (formerly fUnit)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_nasa_forecast_model_web_nfmw_map_service",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "NASA Forecast Model Web (NFMW) Map Service",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_matlab_oslo_toolkit",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "MATLAB-Oslo Toolkit",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_hdf_eos2_hdf_eos5_compatibility_library",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "HDF-EOS2 and HDF-EOS5 Compatibility Library",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_user_friendly_metadata",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "User-Friendly Metadata",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_hdf_eos5_validator",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "HDF-EOS5 Validator",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_hierarchical_data_format_earth_observing_system_hdf_eos_xml_document_type_definitions_schemas",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Hierarchical Data Format Earth Observing System (HDF-EOS) XML Document-Type Definitions and Schemas",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_hierarchical_data_format_earth_observing_system_hdf_eos_metadata_updater_hemu_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Hierarchical Data Format Earth Observing System (HDF-EOS) Metadata Updater (HEMU)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_hierarchical_data_format_earth_observing_system_hdf_eos_web_server",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Hierarchical Data Format Earth Observing System (HDF-EOS) Web Server",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_metadata_check",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Metadata Check",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_odl_to_xml_converter",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "ODL-to-XML Converter",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_xml_to_odl_convertor",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "XML to ODL Convertor",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_hierarchical_data_format_earth_observing_system_hdf_eos_to_netcdf_converter",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Hierarchical Data Format-Earth Observing System (HDF-EOS) to NetCDF Converter",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_matlab_code_v_toolkit",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "MATLAB-Code V Toolkit",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_requirements_tracing_on_target_retro_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Requirements Tracing On Target (RETRO)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_geos_5_global_change_master_modeling_software",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "GEOS-5 Global Change Master Modeling Software",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_global_precipitation_space_ground_radar_comparison_software",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Global Precipitation Space and Ground Radar Comparison Software",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_general_mission_analysis_tool_gmat_version_2011a",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "General Mission Analysis Tool (GMAT), Version 2011A",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_core_flight_executive_cfe_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Core Flight Executive (cFE)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_eeprom_file_system",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "EEPROM File System",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_assert_based_unit_test_tools",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Assert-Based Unit Test Tools",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_worldview_satellite_imagery_browsing_downloading_tool",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Worldview satellite imagery browsing and downloading tool",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_mystran",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "MYSTRAN",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_open_geosocial_consumer_application",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Open GeoSocial Consumer Application",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_vectorization_global_flood_monitoring_system_using_topojson",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Vectorization of Global Flood Monitoring System using Topojson",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_core_flight_system_cfs_software_bus_network_sbn_application_version_1_0",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Core Flight System (CFS) Software Bus Network (SBN) Application, Version 1.0",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_core_flight_system_cfs_cfdp_version_2",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Core Flight System (CFS) CFDP Version 2",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_core_flight_system_cfs_checksum_application_version_2",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Core Flight System (CFS) Checksum Application Version 2",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_core_flight_system_cfs_data_storage_ds_application_version_2",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Core Flight System (CFS) Data Storage (DS) Application Version 2",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_core_flight_system_cfs_file_manager_fm_application_version_2",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Core Flight System (CFS) File Manager (FM) Application Version 2",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_core_flight_system_cfs_housekeeping_hk_application_version_2",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Core Flight System (CFS) Housekeeping (HK) Application Version 2",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_core_flight_system_cfs_health_safety_application_version_2",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Core Flight System (CFS) Health and Safety Application Version 2",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_core_flight_system_cfs_limit_checker_lc_application_version_2",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Core Flight System (CFS) Limit Checker (LC) Application Version 2",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_core_flight_system_cfs_memory_dwell_application_version_2",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Core Flight System (CFS) Memory Dwell Application Version 2",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_core_flight_system_cfs_memory_manager_application_version_2",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Core Flight System (CFS) Memory Manager Application Version 2",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_core_flight_system_cfs_stored_commsc_application_version_2",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Core Flight System (CFS) Stored Command (SC) Application Version 2",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_core_flight_system_cfs_scheduler_application_version_2",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Core Flight System (CFS) Scheduler Application Version 2",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_evolutionary_mission_trajectory_generator_emtg_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Evolutionary Mission Trajectory Generator (EMTG)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_goddard_satellite_data_simulation_unit",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Goddard Satellite Data Simulation Unit",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_integrated_lunar_information_architecture_for_decision_support_iliads_version_3_0",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Integrated Lunar Information Architecture for Decision Support (ILIADS), Version 3.0",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_obs4mips",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Obs4MIPS",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_orbit_determination_toolbox",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Orbit-Determination Toolbox",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_ground_space_radar_volume_matching_and_comparison_software",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Ground and Space Radar Volume Matching and Comparison Software",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_core_hierarchical_segmentation_hseg_software_package",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Core Hierarchical Segmentation (HSEG) Software Package",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_visual_system_for_browsing_analysis_retrieval_data_visbard_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Visual System for Browsing, Analysis, and Retrieval of Data (ViSBARD)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_lossless_hyper_multi_spectral_data_compression_software",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Lossless Hyper-/Multi-Spectral Data Compression Software",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_simple_scalable_script_based_science_processing_archive_s4pa_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Simple, Scalable, Script-based Science Processing Archive (S4PA)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_42_a_comprehensive_general_purpose_simulation_attitude_trajectory_dynamics_and_control_of_multiple_spacecraft_composed_of_multiple_rigid_or_flexible_bodies",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "42: A Comprehensive General-Purpose Simulation of Attitude and Trajectory Dynamics and Control of Multiple Spacecraft Composed of Multiple Rigid or Flexible Bodies",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_landslide_hazard_assessment_for_situational_awareness_lhasa_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Landslide Hazard Assessment for Situational Awareness (LHASA)",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_earthdata_search_web_application",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "Earthdata Search Web Application",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_gsfc_general_mission_analysis_tool_gmat_v_r2016a",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "GSFC",
+          "project_name": "General Mission Analysis Tool (GMAT) v.R2016a",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_jpl_horizon_5_framework_for_distributed_data_management_product_generation_workflow",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "JPL",
+          "project_name": "HORIZON 5 - Framework for distributed data management and product generation workflow",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_jpl_redshift_mobile_app_for_following_tactical_strategic_operations_meeting_schedule",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "JPL",
+          "project_name": "RedShift: mobile app for following the tactical and strategic operations meeting schedule",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_jpl_juneberry_web_service_software",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "JPL",
+          "project_name": "Juneberry Web Service Software",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_jpl_edrn_knowledge_environment",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "JPL",
+          "project_name": "The EDRN Knowledge Environment",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_jpl_demud_discovery_through_eigenbasis_modeling_uninteresting_data",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "JPL",
+          "project_name": "DEMUD: Discovery through Eigenbasis Modeling of Uninteresting Data",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_jpl_dtntap",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "JPL",
+          "project_name": "DTNTAP",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_jpl_dtka_a_prototype_implementation_delay_tolerant_security_key_distribution",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "JPL",
+          "project_name": "DTKA, a Prototype Implementation of Delay-Tolerant Security Key Distribution",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_jpl_juneplum_restful_web_access_opendap_hyrax_back_end_server",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "JPL",
+          "project_name": "Juneplum - ReSTful Web Access of OPeNDAP Hyrax Back End Server",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_jpl_edge_extensible_data_gateway_environment",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "JPL",
+          "project_name": "EDGE - The Extensible Data Gateway Environment",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_jpl_nexus_deep_data_platform",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "JPL",
+          "project_name": "NEXUS: Deep Data Platform",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_jpl_radiometric_calibration_uavsar_images",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "JPL",
+          "project_name": "Radiometric Calibration of UAVSAR Images",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_jpl_gneimo_advanced_techniques_for_constrained_internal_coordinate_molecular_dynamics",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "JPL",
+          "project_name": "GNEIMO Advanced Techniques for Constrained Internal Coordinate Molecular Dynamics",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_jpl_a_web_based_search_service_to_support_imaging_spectrometer_instrument_operations_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "JPL",
+          "project_name": "A Web-based Search Service to Support Imaging Spectrometer Instrument Operations.",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_jpl_oco_2_level_2_retrieval_algorithm",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "JPL",
+          "project_name": "The OCO-2 Level 2 Retrieval Algorithm",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_jpl_vicar_video_image_communication_retrieval",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "JPL",
+          "project_name": "VICAR - Video Image Communication And Retrieval",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_jpl_tie_0_4_imagery_exchange_for_the_nasa_global_imagery_browse_services_gibs_project",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "JPL",
+          "project_name": "TIE 0.4 - The Imagery Exchange for the NASA Global Imagery Browse Services (GIBS) Project",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_jpl_space_mission_architecture_risk_analysis_tool_smart_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "JPL",
+          "project_name": "Space Mission Architecture and Risk Analysis Tool (SMART)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_jpl_cobra_a_code_browser_analyzer_an_extendable_interactive_tool_for_analysis_c_code",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "JPL",
+          "project_name": "Cobra: A Code Browser and Analyzer -- an extendable, interactive tool for the analysis of C code",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_jpl_sysml_system_model_for_thirty_meter_telescope_tmt_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "JPL",
+          "project_name": "SysML System Model for the Thirty Meter Telescope (TMT)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_jpl_ominas_open_source_modular_image_navigation_analysis_system_astronomical_data_processing_software",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "JPL",
+          "project_name": "OMINAS (OPEN-SOURCE MODULAR IMAGE NAVIGATION AND ANALYSIS SYSTEM) astronomical data processing software",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_jpl_imce_ontological_modeling_framework",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "JPL",
+          "project_name": "IMCE Ontological Modeling Framework",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_jpl_earthkit",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "JPL",
+          "project_name": "EarthKit",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_jpl_regional_hydrologic_extremes_assessment_system_rheas_software_framework",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "JPL",
+          "project_name": "Regional Hydrologic Extremes Assessment System (RHEAS) software framework",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_jpl_file_exchange_interface_5_new_enhancements_to_ntr_40075",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "JPL",
+          "project_name": "File Exchange Interface 5 - New enhancements to NTR 40075",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_jpl_ndarts",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "JPL",
+          "project_name": "Ndarts",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_jpl_athena",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "JPL",
+          "project_name": "Athena",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_jpl_oceanographic_data_management_archive_system",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "JPL",
+          "project_name": "Oceanographic Data Management And Archive System",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_jsc_input_device_framework_idf_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "JSC",
+          "project_name": "Input Device Framework (IDF)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_jsc_trick_13_simulation_environment",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "JSC",
+          "project_name": "Trick 13 Simulation Environment",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_accords_conflict_detection_cd3d_conflict_resolution_cr3d_algorithms",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "ACCoRDs Conflict-Detection (CD3D)/Conflict-Resolution (CR3D) Algorithms",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_conflict_prevention_bands",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "Conflict Prevention Bands",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_strategic_conflict_resolution_stratway_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "Strategic Conflict Resolution (Stratway)",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_vehicle_sketch_pad_vsp_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "Vehicle Sketch Pad (VSP)",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_fortran_unit_testing_framework_funit_v1_0_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "Fortran Unit Testing Framework (fUnit v1.0)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_robus_2_fault_tolerant_broadcast_communication_system_for_modular_avionics",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "ROBUS-2 Fault-Tolerant Broadcast Communication System for Modular Avionics",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_tolerance_domain_specific_language",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "Tolerance Domain Specific Language",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_java_based_software_tool_for_dynamic_aerospace_vehicle_exchange_markup_files",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "Java-Based Software Tool for Dynamic Aerospace Vehicle Exchange Markup Files",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_java_program_to_promote_an_open_source_e_standard_for_mass_properties_engineering",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "Java Program to Promote an Open-Source E Standard for Mass Properties Engineering",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_certware_safety_case_workbench_software",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "CertWare Safety Case Workbench Software",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_kodiak_a_software_library_for_verifying_nonlinear_arithmetic_statements",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "Kodiak: A Software Library for Verifying Nonlinear Arithmetic Statements",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_fileplottingtools",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "FilePlottingTools",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_flight_dynamics_simulation_a_generic_transport_model",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "Flight Dynamics Simulation of a Generic Transport Model",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_windows_semi_markov_range_evaluator_winsure_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "Windows Semi-Markov Range Evaluator (WinSURE)",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_winassist_windows_abstract_semi_markov_specification_interface_to_sure_tool_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "WinASSIST: (Windows Abstract Semi-Markov Specification Interface To The SURE Tool)",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_scalable_implementation_finite_elements_by_nasa_scifen_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "Scalable Implementation of Finite Elements by NASA (ScIFEN)",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_composite_damage_compdam_progressive_damage_analysis_software",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "Composite Damage (CompDam) Progressive Damage Analysis Software",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_ceos_data_cube_platform_v_2_ceos2_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "CEOS Data Cube Platform v.2 (CEOS2)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_surface_aquatic_vegetation_detection_tool_savdt_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "Surface Aquatic Vegetation Detection Tool (SAVDT)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_polycarp_algorithms_software_for_computations_with_polygons",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "PolyCARP: Algorithms and Software for Computations with Polygons",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_develop_drip_slip_landslide_detection_package_drip_slip_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "DEVELOP DRIP and SLIP Landslide Detection Package (DRIP-SLIP)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_lsurface_temperature_modis_visualization_lastmov_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "Land Surface Temperature MODIS Visualization (LaSTMoV)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_hypatheon_searchable_database_capability_for_formalized_mathematics",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "Hypatheon-Searchable Database Capability for Formalized Mathematics",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_modified_snowmelt_runoff_model_for_forecasting_water_availability_in_chile",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "Modified Snowmelt Runoff Model For Forecasting Water Availability in Chile",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_abaqus_user_subroutine_verification_abaverify_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "Abaqus User Subroutine Verification (abaverify)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_coastal_mid_atlantic_metric_model",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "Coastal Mid-Atlantic METRIC Model",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_generic_branch_bound_algorithm_for_rigorous_numerical_computations_kodiak_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "Generic Branch and Bound Algorithm for Rigorous Numerical Computations (KODIAK)",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_nasa_structrual_analysis_nastran_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "NASA STRuctrual ANalysis (NASTRAN)",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_icarous_communication_decision_making_software_modules",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "ICAROUS' Communication and Decision Making Software Modules",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_larc_well_clear_violation_volumes_for_concept_integration_of_uas_in_nas",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "LaRC",
+          "project_name": "Well-Clear Violation Volumes for Concept of Integration of UAS in the NAS",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_msfc_tool_for_analysis_surface_cracks_tasc_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "MSFC",
+          "project_name": "Tool for Analysis of Surface Cracks (TASC)",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_msfc_libsprite",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "MSFC",
+          "project_name": "libSPRITE",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_msfc_marshall_mrms_mosaic_python_toolkit_mmm_py_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "MSFC",
+          "project_name": "Marshall MRMS Mosaic Python Toolkit (MMM-Py)",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_msfc_python_advanced_microwave_precipitation_radiometer_data_toolkit_pyampr_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "MSFC",
+          "project_name": "Python Advanced Microwave Precipitation Radiometer Data Toolkit (PyAMPR)",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_msfc_python_turbulence_detection_algorithm_pytda_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "MSFC",
+          "project_name": "Python Turbulence Detection Algorithm (PyTDA)",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_msfc_python_interface_to_dual_pol_radar_algorithms_dualpol_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "MSFC",
+          "project_name": "Python Interface to Dual-Pol Radar Algorithms (DualPol)",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        },
+        {
+          "repoID": "nasa_msfc_python_polarimetric_radar_beam_blockage_calculation_pyblock_",
+          "agency": "National Aeronautics and Space Administration",
+          "organization": "MSFC",
+          "project_name": "Python Polarimetric Radar Beam Blockage Calculation (PyBlock)",
+          "issues": {
+            "enhancements": [],
+            "warnings": [
+              {
+                "keyword": "format",
+                "dataPath": ".repository",
+                "schemaPath": "#/properties/repository/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "errors": []
+          }
+        }
+      ],
       "version": "1.0.1",
       "metadata": {
         "agency": {
           "name": "National Aeronautics and Space Administration",
           "acronym": "NASA",
           "website": "https://nasa.gov/",
-          "codeUrl": "https://code.nasa.gov/code.json",
+          "codeUrl": "/data/fallback/NASA.json",
           "requirements": {
             "agencyWidePolicy": 1,
             "openSourceRequirement": 1,
             "inventoryRequirement": 0.5,
-            "schemaFormat": 1,
-            "overallCompliance": 0.875
+            "schemaFormat": 0.5,
+            "overallCompliance": 0.8333333333333334
           }
         }
       },
@@ -1627,26 +8402,27 @@
         "agencyWidePolicy": 1,
         "openSourceRequirement": 1,
         "inventoryRequirement": 0.5,
-        "schemaFormat": 1,
-        "overallCompliance": 0.875
+        "schemaFormat": 0.5,
+        "overallCompliance": 0.8333333333333334
       }
     },
     "AID": {
-      "status": "FULLY COMPLIANT: 0 validation errors",
+      "status": "FAILURE: MISSING PROJECTS FIELD",
       "issues": [],
-      "version": "1.0.1",
+      "version": "",
       "metadata": {
         "agency": {
+          "id": 17,
           "name": "Agency for International Development",
           "acronym": "AID",
           "website": "https://usaid.gov/",
-          "codeUrl": "https://usaid.gov/code.json",
+          "codeUrl": "/data/fallback/AID.json",
           "requirements": {
             "agencyWidePolicy": 1,
             "openSourceRequirement": 0,
             "inventoryRequirement": 0.5,
-            "schemaFormat": 1,
-            "overallCompliance": 0.625
+            "schemaFormat": 0,
+            "overallCompliance": 0.5
           }
         }
       },
@@ -1654,12 +8430,12 @@
         "agencyWidePolicy": 1,
         "openSourceRequirement": 0,
         "inventoryRequirement": 0.5,
-        "schemaFormat": 1,
-        "overallCompliance": 0.625
+        "schemaFormat": 0,
+        "overallCompliance": 0.5
       }
     },
     "FEMA": {
-      "status": "FAILURE: ERROR WHEN FETCHING (Unexpected token < in JSON at position 0)",
+      "status": "FAILURE: MISSING PROJECTS FIELD",
       "issues": [],
       "version": "",
       "metadata": {
@@ -1668,7 +8444,7 @@
           "name": "Federal Emergency Management Agency",
           "acronym": "FEMA",
           "website": "https://fema.gov/",
-          "codeUrl": "https://fema.gov/code.json",
+          "codeUrl": "/data/fallback/FEMA.json",
           "requirements": {
             "agencyWidePolicy": null,
             "openSourceRequirement": null,
@@ -1687,15890 +8463,30 @@
       }
     },
     "GSA": {
-      "status": "NOT FULLY COMPLIANT: 793 ERRORS, 793 validation errors",
-      "issues": [
-        {
-          "repoID": "gsa_government_urls",
-          "agency": "General Services Administration",
-          "project_name": "Government URLs",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_search_digitalgov_gov",
-          "agency": "General Services Administration",
-          "project_name": "Search.digitalgov.gov",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_open_gsa_gov",
-          "agency": "General Services Administration",
-          "project_name": "open.gsa.gov",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_asis",
-          "agency": "General Services Administration",
-          "project_name": "ASIS",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "description"
-                },
-                "message": "should have required property 'description'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_digitalgov_search_content_assets",
-          "agency": "General Services Administration",
-          "project_name": "DigitalGov Search Content Assets",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_https_cio_gov",
-          "agency": "General Services Administration",
-          "project_name": "https.cio.gov",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_digitalgov_search_i14y_slate",
-          "agency": "General Services Administration",
-          "project_name": "DigitalGov Search i14y Slate",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_scopeid_script",
-          "agency": "General Services Administration",
-          "project_name": "ScopeID Script",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_federal_identity_credential_access_management_roadmap",
-          "agency": "General Services Administration",
-          "project_name": "Federal Identity, Credential and Access Management Roadmap",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_gsa_document_signing_tools",
-          "agency": "General Services Administration",
-          "project_name": "GSA Document Signing Tools",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_federal_public_key_infrastructure_fpki_guides",
-          "agency": "General Services Administration",
-          "project_name": "Federal Public Key Infrastructure (FPKI) Guides",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_federal_personal_identity_verification_piv_guides",
-          "agency": "General Services Administration",
-          "project_name": "Federal Personal Identity Verification (PIV) Guides",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pbs_sensor",
-          "agency": "General Services Administration",
-          "project_name": "PBS Sensor",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cto_website",
-          "agency": "General Services Administration",
-          "project_name": "CTO Website",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_open_gsa_gov_redesign",
-          "agency": "General Services Administration",
-          "project_name": "open.gsa.gov Redesign",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_gwac",
-          "agency": "General Services Administration",
-          "project_name": "GWAC",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "description"
-                },
-                "message": "should have required property 'description'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_gsa_open_source_policy",
-          "agency": "General Services Administration",
-          "project_name": "GSA Open Source Policy",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_codeinventory_metadata_generator",
-          "agency": "General Services Administration",
-          "project_name": "CodeInventory Metadata Generator",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_codeinventory",
-          "agency": "General Services Administration",
-          "project_name": "CodeInventory",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_codeinventory_github",
-          "agency": "General Services Administration",
-          "project_name": "CodeInventory GitHub",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_api_data_gov",
-          "agency": "General Services Administration",
-          "project_name": "api.data.gov",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_omniauth_myusa",
-          "agency": "General Services Administration",
-          "project_name": "omniauth-myusa",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pricehistoryapi",
-          "agency": "General Services Administration",
-          "project_name": "PriceHistoryAPI",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_morrisdatadecorator",
-          "agency": "General Services Administration",
-          "project_name": "MorrisDataDecorator",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_fbopen",
-          "agency": "General Services Administration",
-          "project_name": "fbopen",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_fbopen_widget",
-          "agency": "General Services Administration",
-          "project_name": "fbopen-widget",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_xavier",
-          "agency": "General Services Administration",
-          "project_name": "xavier",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pricehistorygui",
-          "agency": "General Services Administration",
-          "project_name": "PriceHistoryGUI",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pricehistoryauth",
-          "agency": "General Services Administration",
-          "project_name": "PriceHistoryAuth",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_microp3apiuser",
-          "agency": "General Services Administration",
-          "project_name": "MicroP3ApiUser",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pif_interest",
-          "agency": "General Services Administration",
-          "project_name": "pif-interest",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_api_usability_testing",
-          "agency": "General Services Administration",
-          "project_name": "API-Usability-Testing",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pif_app",
-          "agency": "General Services Administration",
-          "project_name": "pif-app",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_ifgovthenthat",
-          "agency": "General Services Administration",
-          "project_name": "ifgovthenthat",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_18f_gsa_gov",
-          "agency": "General Services Administration",
-          "project_name": "18f.gsa.gov",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_18f_github_io",
-          "agency": "General Services Administration",
-          "project_name": "18f.github.io",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_brutus",
-          "agency": "General Services Administration",
-          "project_name": "brutus",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_mario",
-          "agency": "General Services Administration",
-          "project_name": "Mario",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_afsmallbiz",
-          "agency": "General Services Administration",
-          "project_name": "afsmallbiz",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_api_all_x",
-          "agency": "General Services Administration",
-          "project_name": "API-All-the-X",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_api_standards",
-          "agency": "General Services Administration",
-          "project_name": "api-standards",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pif_logo_v2",
-          "agency": "General Services Administration",
-          "project_name": "PIF-logo-v2",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_sbhub",
-          "agency": "General Services Administration",
-          "project_name": "sbhub",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_gsa_advantage_scrape",
-          "agency": "General Services Administration",
-          "project_name": "gsa-advantage-scrape",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_scrapebox",
-          "agency": "General Services Administration",
-          "project_name": "scrapebox",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_c2",
-          "agency": "General Services Administration",
-          "project_name": "C2",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_randomizebasedonzipcodefromipaddress",
-          "agency": "General Services Administration",
-          "project_name": "RandomizeBasedOnZipcodeFromIPAddress",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_afsbirez",
-          "agency": "General Services Administration",
-          "project_name": "afsbirez",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_beckley",
-          "agency": "General Services Administration",
-          "project_name": "beckley",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_open_source_program",
-          "agency": "General Services Administration",
-          "project_name": "open-source-program",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pricehistoryinstall",
-          "agency": "General Services Administration",
-          "project_name": "PriceHistoryInstall",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_myusa",
-          "agency": "General Services Administration",
-          "project_name": "myusa",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_digital_coworking",
-          "agency": "General Services Administration",
-          "project_name": "Digital_Coworking",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_notalone",
-          "agency": "General Services Administration",
-          "project_name": "notalone",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_bronto_api",
-          "agency": "General Services Administration",
-          "project_name": "bronto-api",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_open_source_policy",
-          "agency": "General Services Administration",
-          "project_name": "open-source-policy",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_scratch",
-          "agency": "General Services Administration",
-          "project_name": "scratch",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_github_in_government",
-          "agency": "General Services Administration",
-          "project_name": "github-in-government",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_foia",
-          "agency": "General Services Administration",
-          "project_name": "foia",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_bronto",
-          "agency": "General Services Administration",
-          "project_name": "bronto",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_codetalker",
-          "agency": "General Services Administration",
-          "project_name": "codetalker",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_dodsbir_scrape",
-          "agency": "General Services Administration",
-          "project_name": "dodsbir-scrape",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_g_analytics",
-          "agency": "General Services Administration",
-          "project_name": "g-analytics",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_fbopen_docs",
-          "agency": "General Services Administration",
-          "project_name": "fbopen-docs",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_design",
-          "agency": "General Services Administration",
-          "project_name": "design",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cookbooks",
-          "agency": "General Services Administration",
-          "project_name": "cookbooks",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_rectangle",
-          "agency": "General Services Administration",
-          "project_name": "rectangle",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_foia_design",
-          "agency": "General Services Administration",
-          "project_name": "foia-design",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_foia_hub",
-          "agency": "General Services Administration",
-          "project_name": "foia-hub",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_foia_search",
-          "agency": "General Services Administration",
-          "project_name": "foia-search",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_javascript_lessons",
-          "agency": "General Services Administration",
-          "project_name": "javascript-lessons",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_docker_es",
-          "agency": "General Services Administration",
-          "project_name": "docker-es",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_doi_extractives_data",
-          "agency": "General Services Administration",
-          "project_name": "doi-extractives-data",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_parse_shopping_list",
-          "agency": "General Services Administration",
-          "project_name": "parse-shopping-list",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_conway_game_life_js",
-          "agency": "General Services Administration",
-          "project_name": "conway-game-of-life-js",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_discovery",
-          "agency": "General Services Administration",
-          "project_name": "discovery",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_fec",
-          "agency": "General Services Administration",
-          "project_name": "FEC",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_answers_ruby_client",
-          "agency": "General Services Administration",
-          "project_name": "answers-ruby-client",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_vagrant_chef_elasticsearch",
-          "agency": "General Services Administration",
-          "project_name": "vagrant-chef-elasticsearch",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_fbopen_python",
-          "agency": "General Services Administration",
-          "project_name": "fbopen-python",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_myra",
-          "agency": "General Services Administration",
-          "project_name": "myra",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_sqlalchemy_jsonapi",
-          "agency": "General Services Administration",
-          "project_name": "sqlalchemy-jsonapi",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_got",
-          "agency": "General Services Administration",
-          "project_name": "GoT",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pyfpds",
-          "agency": "General Services Administration",
-          "project_name": "pyfpds",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_fec_graph_search",
-          "agency": "General Services Administration",
-          "project_name": "fec-graph-search",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_playbook",
-          "agency": "General Services Administration",
-          "project_name": "playbook",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_openfec",
-          "agency": "General Services Administration",
-          "project_name": "openFEC",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_https",
-          "agency": "General Services Administration",
-          "project_name": "https",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_aaa_exp_proto1",
-          "agency": "General Services Administration",
-          "project_name": "aaa-exp-proto1",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_fab",
-          "agency": "General Services Administration",
-          "project_name": "FAB",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_dashboard",
-          "agency": "General Services Administration",
-          "project_name": "dashboard",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_consulting",
-          "agency": "General Services Administration",
-          "project_name": "consulting",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_microsite_template_18f",
-          "agency": "General Services Administration",
-          "project_name": "microsite-template-18f",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_microsite_18f",
-          "agency": "General Services Administration",
-          "project_name": "microsite-18f",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_mock_pay",
-          "agency": "General Services Administration",
-          "project_name": "mock-pay",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_18f_bot",
-          "agency": "General Services Administration",
-          "project_name": "18f-bot",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_hackathontrainingday",
-          "agency": "General Services Administration",
-          "project_name": "hackathontrainingday",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_how_to_work_with_18f",
-          "agency": "General Services Administration",
-          "project_name": "how-to-work-with-18f",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_sendak",
-          "agency": "General Services Administration",
-          "project_name": "Sendak",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_shipper",
-          "agency": "General Services Administration",
-          "project_name": "shipper",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_gsa_auctions_gem",
-          "agency": "General Services Administration",
-          "project_name": "gsa_auctions_gem",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_frontend",
-          "agency": "General Services Administration",
-          "project_name": "frontend",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_inclusive_design_guide",
-          "agency": "General Services Administration",
-          "project_name": "inclusive-design-guide",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_open_opportunities_theme",
-          "agency": "General Services Administration",
-          "project_name": "open-opportunities-theme",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_starter_ui",
-          "agency": "General Services Administration",
-          "project_name": "starter-ui",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_bulk_storage",
-          "agency": "General Services Administration",
-          "project_name": "bulk-storage",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_openfec_web_app",
-          "agency": "General Services Administration",
-          "project_name": "openFEC-web-app",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_shipper_cookbook",
-          "agency": "General Services Administration",
-          "project_name": "shipper-cookbook",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pif3_oct_apprentice",
-          "agency": "General Services Administration",
-          "project_name": "pif3-oct-apprentice",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pif3_oct_whibrary",
-          "agency": "General Services Administration",
-          "project_name": "pif3-oct-whibrary",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_code_conduct",
-          "agency": "General Services Administration",
-          "project_name": "code-of-conduct",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_mirage_cookbook",
-          "agency": "General Services Administration",
-          "project_name": "mirage-cookbook",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_peacecorps_placeholder_images",
-          "agency": "General Services Administration",
-          "project_name": "peacecorps-placeholder-images",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_up",
-          "agency": "General Services Administration",
-          "project_name": "up",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_rdbms_subsetter",
-          "agency": "General Services Administration",
-          "project_name": "rdbms-subsetter",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_sendak_usage",
-          "agency": "General Services Administration",
-          "project_name": "sendak-usage",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_analytics_proxy",
-          "agency": "General Services Administration",
-          "project_name": "analytics-proxy",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_myusa_cookbook",
-          "agency": "General Services Administration",
-          "project_name": "myusa-cookbook",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_18fconsulting_proto_3",
-          "agency": "General Services Administration",
-          "project_name": "18fconsulting-proto-3",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_api_playground",
-          "agency": "General Services Administration",
-          "project_name": "api-playground",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_calc",
-          "agency": "General Services Administration",
-          "project_name": "calc",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_email_to_github_issues",
-          "agency": "General Services Administration",
-          "project_name": "email-to-github-issues",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_data_public",
-          "agency": "General Services Administration",
-          "project_name": "data-public",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_ckanext_geodatagov",
-          "agency": "General Services Administration",
-          "project_name": "ckanext-geodatagov",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_ckanext_spatial",
-          "agency": "General Services Administration",
-          "project_name": "ckanext-spatial",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_ckanext_formats",
-          "agency": "General Services Administration",
-          "project_name": "ckanext-formats",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_analytics_reporter",
-          "agency": "General Services Administration",
-          "project_name": "analytics-reporter",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_domain_scan",
-          "agency": "General Services Administration",
-          "project_name": "domain-scan",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_flakes_flask",
-          "agency": "General Services Administration",
-          "project_name": "flakes-flask",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_usps_proxy",
-          "agency": "General Services Administration",
-          "project_name": "usps-proxy",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_hub",
-          "agency": "General Services Administration",
-          "project_name": "hub",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_midas_cookbook",
-          "agency": "General Services Administration",
-          "project_name": "midas-cookbook",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_ubuntu_lts",
-          "agency": "General Services Administration",
-          "project_name": "ubuntu-lts",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_hourofcode",
-          "agency": "General Services Administration",
-          "project_name": "hourofcode",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_data_validator",
-          "agency": "General Services Administration",
-          "project_name": "data-validator",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_hash_joiner",
-          "agency": "General Services Administration",
-          "project_name": "hash-joiner",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_sails_postgresql",
-          "agency": "General Services Administration",
-          "project_name": "sails-postgresql",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_usps_api_notes",
-          "agency": "General Services Administration",
-          "project_name": "usps-api-notes",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_django_elasticache",
-          "agency": "General Services Administration",
-          "project_name": "django-elasticache",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_analytics_usa_gov",
-          "agency": "General Services Administration",
-          "project_name": "analytics.usa.gov",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_docker_fugacious",
-          "agency": "General Services Administration",
-          "project_name": "docker-fugacious",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_weekly_snippets",
-          "agency": "General Services Administration",
-          "project_name": "weekly_snippets",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_before_you_ship",
-          "agency": "General Services Administration",
-          "project_name": "before-you-ship",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_ckanext_datajson",
-          "agency": "General Services Administration",
-          "project_name": "ckanext-datajson",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_dashboards_on_demand",
-          "agency": "General Services Administration",
-          "project_name": "dashboards-on-demand",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_team_hub",
-          "agency": "General Services Administration",
-          "project_name": "team_hub",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_test_temp_file_helper",
-          "agency": "General Services Administration",
-          "project_name": "test_temp_file_helper",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_sendak_touch",
-          "agency": "General Services Administration",
-          "project_name": "sendak-touch",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_jekyll_pages_api",
-          "agency": "General Services Administration",
-          "project_name": "jekyll_pages_api",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_openfec_documentation",
-          "agency": "General Services Administration",
-          "project_name": "openFEC-documentation",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_automated_testing_playbook",
-          "agency": "General Services Administration",
-          "project_name": "automated-testing-playbook",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_site",
-          "agency": "General Services Administration",
-          "project_name": "cg-site",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_accessibility",
-          "agency": "General Services Administration",
-          "project_name": "accessibility",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_tock",
-          "agency": "General Services Administration",
-          "project_name": "tock",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_grouplet_playbook",
-          "agency": "General Services Administration",
-          "project_name": "grouplet-playbook",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_ficam_openid",
-          "agency": "General Services Administration",
-          "project_name": "ficam-openid",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_agile",
-          "agency": "General Services Administration",
-          "project_name": "agile",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_django_rest_swagger",
-          "agency": "General Services Administration",
-          "project_name": "django-rest-swagger",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_training",
-          "agency": "General Services Administration",
-          "project_name": "training",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_guides",
-          "agency": "General Services Administration",
-          "project_name": "guides",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_api_program",
-          "agency": "General Services Administration",
-          "project_name": "api-program",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_tourney",
-          "agency": "General Services Administration",
-          "project_name": "tourney",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cf_deploy",
-          "agency": "General Services Administration",
-          "project_name": "cf-deploy",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_data_inventory",
-          "agency": "General Services Administration",
-          "project_name": "data-inventory",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_manifests",
-          "agency": "General Services Administration",
-          "project_name": "cg-manifests",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_doc_processing_toolkit",
-          "agency": "General Services Administration",
-          "project_name": "doc_processing_toolkit",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_myths",
-          "agency": "General Services Administration",
-          "project_name": "myths",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_solrstrap",
-          "agency": "General Services Administration",
-          "project_name": "solrstrap",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_testing_cookbook",
-          "agency": "General Services Administration",
-          "project_name": "testing-cookbook",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_agile_labor_categories",
-          "agency": "General Services Administration",
-          "project_name": "agile-labor-categories",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_data_act_schemas",
-          "agency": "General Services Administration",
-          "project_name": "data-act-schemas",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_hackathons",
-          "agency": "General Services Administration",
-          "project_name": "hackathons",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_quotable",
-          "agency": "General Services Administration",
-          "project_name": "quotable",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_django_gzipping_cache",
-          "agency": "General Services Administration",
-          "project_name": "django-gzipping-cache",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_project_monitor",
-          "agency": "General Services Administration",
-          "project_name": "project-monitor",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_usds_hub",
-          "agency": "General Services Administration",
-          "project_name": "usds-hub",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_myusa_ux",
-          "agency": "General Services Administration",
-          "project_name": "myusa-ux",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_protosketch_demo",
-          "agency": "General Services Administration",
-          "project_name": "protosketch-demo",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_urlsize",
-          "agency": "General Services Administration",
-          "project_name": "urlsize",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_metascraper",
-          "agency": "General Services Administration",
-          "project_name": "metascraper",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_laptop",
-          "agency": "General Services Administration",
-          "project_name": "laptop",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_harden_boshrelease",
-          "agency": "General Services Administration",
-          "project_name": "cg-harden-boshrelease",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_python_buildpack",
-          "agency": "General Services Administration",
-          "project_name": "python-buildpack",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pulse",
-          "agency": "General Services Administration",
-          "project_name": "pulse",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_ckanext_datesearch",
-          "agency": "General Services Administration",
-          "project_name": "ckanext-datesearch",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_ideas",
-          "agency": "General Services Administration",
-          "project_name": "ideas",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_scorecard",
-          "agency": "General Services Administration",
-          "project_name": "scorecard",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_d3_technical_debt",
-          "agency": "General Services Administration",
-          "project_name": "d3-technical-debt",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cf_sinatra_ci",
-          "agency": "General Services Administration",
-          "project_name": "cf-sinatra-ci",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_financial_models",
-          "agency": "General Services Administration",
-          "project_name": "financial-models",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_sauceclient",
-          "agency": "General Services Administration",
-          "project_name": "sauceclient",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_mapwarper_metadata",
-          "agency": "General Services Administration",
-          "project_name": "mapwarper_metadata",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_oauth2_proxy",
-          "agency": "General Services Administration",
-          "project_name": "oauth2_proxy",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_abb",
-          "agency": "General Services Administration",
-          "project_name": "abb",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_data_act_sf133",
-          "agency": "General Services Administration",
-          "project_name": "data-act-sf133",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_r2s",
-          "agency": "General Services Administration",
-          "project_name": "r2s",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_continua11y",
-          "agency": "General Services Administration",
-          "project_name": "continua11y",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_scripts",
-          "agency": "General Services Administration",
-          "project_name": "cg-scripts",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_jekyll_get",
-          "agency": "General Services Administration",
-          "project_name": "jekyll-get",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cf_ssh",
-          "agency": "General Services Administration",
-          "project_name": "cf-ssh",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_fedspendingtransparency_github_io",
-          "agency": "General Services Administration",
-          "project_name": "fedspendingtransparency.github.io",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_eiti_data",
-          "agency": "General Services Administration",
-          "project_name": "eiti-data",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_data_act_workshop",
-          "agency": "General Services Administration",
-          "project_name": "data-act-workshop",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_slides",
-          "agency": "General Services Administration",
-          "project_name": "slides",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_rds_service_broker",
-          "agency": "General Services Administration",
-          "project_name": "rds-service-broker",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_myusa_coming_soon",
-          "agency": "General Services Administration",
-          "project_name": "myusa-coming-soon",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_project_monitor_helper",
-          "agency": "General Services Administration",
-          "project_name": "project-monitor-helper",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cli",
-          "agency": "General Services Administration",
-          "project_name": "cli",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_analytics_standards",
-          "agency": "General Services Administration",
-          "project_name": "analytics-standards",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_508_procurement_playbook",
-          "agency": "General Services Administration",
-          "project_name": "508-procurement-playbook",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_sslmate_cookbook",
-          "agency": "General Services Administration",
-          "project_name": "sslmate-cookbook",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_core_values",
-          "agency": "General Services Administration",
-          "project_name": "core-values",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cloud_foundry_client_js",
-          "agency": "General Services Administration",
-          "project_name": "cloud-foundry-client-js",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_fees_labor_rates",
-          "agency": "General Services Administration",
-          "project_name": "fees-and-labor-rates",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_autoapi",
-          "agency": "General Services Administration",
-          "project_name": "autoapi",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_dol_whd_foh",
-          "agency": "General Services Administration",
-          "project_name": "dol-whd-foh",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_guides_template",
-          "agency": "General Services Administration",
-          "project_name": "guides-template",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pa11y_reporter_ci",
-          "agency": "General Services Administration",
-          "project_name": "pa11y-reporter-ci",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_node_sauce_template",
-          "agency": "General Services Administration",
-          "project_name": "node-sauce-template",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_wmsviewer",
-          "agency": "General Services Administration",
-          "project_name": "WMSViewer",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_methods",
-          "agency": "General Services Administration",
-          "project_name": "methods",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_data_act_pilot",
-          "agency": "General Services Administration",
-          "project_name": "data-act-pilot",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pages",
-          "agency": "General Services Administration",
-          "project_name": "pages",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_slackin",
-          "agency": "General Services Administration",
-          "project_name": "slackin",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_jekyll_search_server",
-          "agency": "General Services Administration",
-          "project_name": "jekyll-search-server",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_what_is_devops",
-          "agency": "General Services Administration",
-          "project_name": "what-is-devops",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_joining_18f",
-          "agency": "General Services Administration",
-          "project_name": "joining-18f",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_procurement_glossary",
-          "agency": "General Services Administration",
-          "project_name": "procurement-glossary",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_lean_product_design",
-          "agency": "General Services Administration",
-          "project_name": "lean-product-design",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_charmander",
-          "agency": "General Services Administration",
-          "project_name": "charmander",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_polyfill_service",
-          "agency": "General Services Administration",
-          "project_name": "polyfill-service",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_docker_elasticsearch",
-          "agency": "General Services Administration",
-          "project_name": "docker-elasticsearch",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_hubot_cf_notifications",
-          "agency": "General Services Administration",
-          "project_name": "hubot-cf-notifications",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_sbirez_prototype",
-          "agency": "General Services Administration",
-          "project_name": "sbirez-prototype",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_fec_alpha",
-          "agency": "General Services Administration",
-          "project_name": "fec-alpha",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pa11y_dashboard",
-          "agency": "General Services Administration",
-          "project_name": "pa11y-dashboard",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_gitter",
-          "agency": "General Services Administration",
-          "project_name": "gitter",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_ekip",
-          "agency": "General Services Administration",
-          "project_name": "ekip",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cf_hello_worlds",
-          "agency": "General Services Administration",
-          "project_name": "cf-hello-worlds",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_quotas_db",
-          "agency": "General Services Administration",
-          "project_name": "cg-quotas-db",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_data_act_csv_export",
-          "agency": "General Services Administration",
-          "project_name": "data-act-csv-export",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_ekip_api",
-          "agency": "General Services Administration",
-          "project_name": "ekip-api",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_record_locator",
-          "agency": "General Services Administration",
-          "project_name": "record-locator",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_billing_tools",
-          "agency": "General Services Administration",
-          "project_name": "billing-tools",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_education_compliance_reports",
-          "agency": "General Services Administration",
-          "project_name": "education-compliance-reports",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_military_onesource_federalist",
-          "agency": "General Services Administration",
-          "project_name": "military-onesource-federalist",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_citysdk_innov_district",
-          "agency": "General Services Administration",
-          "project_name": "citysdk-innov-district",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_github_dashing",
-          "agency": "General Services Administration",
-          "project_name": "github-dashing",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_web_design_standards",
-          "agency": "General Services Administration",
-          "project_name": "web-design-standards",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_angular_livesearch",
-          "agency": "General Services Administration",
-          "project_name": "angular-livesearch",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_jekyll_pages_api_search",
-          "agency": "General Services Administration",
-          "project_name": "jekyll_pages_api_search",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_collector",
-          "agency": "General Services Administration",
-          "project_name": "collector",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_cf_release",
-          "agency": "General Services Administration",
-          "project_name": "cg-cf-release",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_agile_solicitation_builder",
-          "agency": "General Services Administration",
-          "project_name": "agile-solicitation-builder",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_federalist",
-          "agency": "General Services Administration",
-          "project_name": "federalist",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_jekyll_data_migrate",
-          "agency": "General Services Administration",
-          "project_name": "jekyll-data-migrate",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_ads_bpa",
-          "agency": "General Services Administration",
-          "project_name": "ads-bpa",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_django_pyodbc",
-          "agency": "General Services Administration",
-          "project_name": "django-pyodbc",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_django_pyodbc_access",
-          "agency": "General Services Administration",
-          "project_name": "django-pyodbc-access",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_swagger_ui",
-          "agency": "General Services Administration",
-          "project_name": "swagger-ui",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_data_act_usaspending",
-          "agency": "General Services Administration",
-          "project_name": "data-act-usaspending",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cf_provision_user_space_plugin",
-          "agency": "General Services Administration",
-          "project_name": "cf-provision-user-space-plugin",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_open_data_maker",
-          "agency": "General Services Administration",
-          "project_name": "open-data-maker",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_myusa_rails_example",
-          "agency": "General Services Administration",
-          "project_name": "myusa-rails-example",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_wg_testing",
-          "agency": "General Services Administration",
-          "project_name": "wg-testing",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_web_design_standards_assets",
-          "agency": "General Services Administration",
-          "project_name": "web-design-standards-assets",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_devops_assessment",
-          "agency": "General Services Administration",
-          "project_name": "devops-assessment",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_iaa_gem",
-          "agency": "General Services Administration",
-          "project_name": "iaa-gem",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_hookshot",
-          "agency": "General Services Administration",
-          "project_name": "hookshot",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_design_principles_guide",
-          "agency": "General Services Administration",
-          "project_name": "design-principles-guide",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_django_pgjson",
-          "agency": "General Services Administration",
-          "project_name": "django-pgjson",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_jekyll",
-          "agency": "General Services Administration",
-          "project_name": "jekyll",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_noaabigdata_code",
-          "agency": "General Services Administration",
-          "project_name": "noaabigdata-code",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_guard_rspec",
-          "agency": "General Services Administration",
-          "project_name": "guard-rspec",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_cron",
-          "agency": "General Services Administration",
-          "project_name": "cg-cron",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_json",
-          "agency": "General Services Administration",
-          "project_name": "json",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_case_study_guide",
-          "agency": "General Services Administration",
-          "project_name": "case-study-guide",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_iaa_forms",
-          "agency": "General Services Administration",
-          "project_name": "iaa-forms",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_content_guide",
-          "agency": "General Services Administration",
-          "project_name": "content-guide",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_voyage",
-          "agency": "General Services Administration",
-          "project_name": "voyage",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_gittem_gitlab",
-          "agency": "General Services Administration",
-          "project_name": "gittem-gitlab",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_gittem_view",
-          "agency": "General Services Administration",
-          "project_name": "gittem-view",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_secureproxy_boshrelease",
-          "agency": "General Services Administration",
-          "project_name": "cg-secureproxy-boshrelease",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_e_manifest",
-          "agency": "General Services Administration",
-          "project_name": "e-manifest",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cms_gov_developer",
-          "agency": "General Services Administration",
-          "project_name": "CMS.gov-developer",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_certificate_service",
-          "agency": "General Services Administration",
-          "project_name": "certificate-service",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_site_data",
-          "agency": "General Services Administration",
-          "project_name": "site-data",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_dashboard",
-          "agency": "General Services Administration",
-          "project_name": "cg-dashboard",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_edu_accessibility",
-          "agency": "General Services Administration",
-          "project_name": "edu-accessibility",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_iaa_mvp",
-          "agency": "General Services Administration",
-          "project_name": "iaa-mvp",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cf_meteor_buildpack",
-          "agency": "General Services Administration",
-          "project_name": "cf-meteor-buildpack",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_dev_environment",
-          "agency": "General Services Administration",
-          "project_name": "dev-environment",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_data_act_pilot_prototype",
-          "agency": "General Services Administration",
-          "project_name": "data-act-pilot-prototype",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_open_source_guide",
-          "agency": "General Services Administration",
-          "project_name": "open-source-guide",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_govconnect",
-          "agency": "General Services Administration",
-          "project_name": "govconnect",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_federalist_content_guide",
-          "agency": "General Services Administration",
-          "project_name": "federalist-content-guide",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_data_voyage",
-          "agency": "General Services Administration",
-          "project_name": "data-voyage",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_idea_box",
-          "agency": "General Services Administration",
-          "project_name": "idea-box",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_jekyll_frontmatter_tests",
-          "agency": "General Services Administration",
-          "project_name": "jekyll_frontmatter_tests",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cf_blue_green",
-          "agency": "General Services Administration",
-          "project_name": "cf-blue-green",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_iaa_mvp_buildpack",
-          "agency": "General Services Administration",
-          "project_name": "iaa-mvp-buildpack",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_fec_style",
-          "agency": "General Services Administration",
-          "project_name": "fec-style",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_iaa_pdf_api",
-          "agency": "General Services Administration",
-          "project_name": "iaa-pdf-api",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_landing",
-          "agency": "General Services Administration",
-          "project_name": "cg-landing",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pa11y_scan",
-          "agency": "General Services Administration",
-          "project_name": "pa11y-scan",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_edu",
-          "agency": "General Services Administration",
-          "project_name": "edu",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_ruby_saml",
-          "agency": "General Services Administration",
-          "project_name": "ruby-saml",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_fec_cms",
-          "agency": "General Services Administration",
-          "project_name": "fec-cms",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_guides_style",
-          "agency": "General Services Administration",
-          "project_name": "guides-style",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_wg_documentation",
-          "agency": "General Services Administration",
-          "project_name": "wg-documentation",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_wg_working_groups",
-          "agency": "General Services Administration",
-          "project_name": "wg-working-groups",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_connect_vbms",
-          "agency": "General Services Administration",
-          "project_name": "connect_vbms",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_go_script",
-          "agency": "General Services Administration",
-          "project_name": "go_script",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pyhappyornot",
-          "agency": "General Services Administration",
-          "project_name": "pyHappyOrNot",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_contracting_cookbook",
-          "agency": "General Services Administration",
-          "project_name": "contracting-cookbook",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_peek_delayed_job",
-          "agency": "General Services Administration",
-          "project_name": "peek-delayed_job",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_css_linter",
-          "agency": "General Services Administration",
-          "project_name": "css-linter",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cms_apis",
-          "agency": "General Services Administration",
-          "project_name": "CMS-APIs",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_bpa_dash",
-          "agency": "General Services Administration",
-          "project_name": "bpa-dash",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_intake",
-          "agency": "General Services Administration",
-          "project_name": "intake",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_fr_notices",
-          "agency": "General Services Administration",
-          "project_name": "fr-notices",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_about_yml",
-          "agency": "General Services Administration",
-          "project_name": "about_yml",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_team_api",
-          "agency": "General Services Administration",
-          "project_name": "team_api",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_elk_docker",
-          "agency": "General Services Administration",
-          "project_name": "elk-docker",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_tech_talks",
-          "agency": "General Services Administration",
-          "project_name": "tech-talks",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_usps",
-          "agency": "General Services Administration",
-          "project_name": "usps",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_epa_emanifest_data",
-          "agency": "General Services Administration",
-          "project_name": "epa-emanifest-data",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_e_manifest_cromerr_client",
-          "agency": "General Services Administration",
-          "project_name": "e-manifest-cromerr-client",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_federalist_modern_team_template",
-          "agency": "General Services Administration",
-          "project_name": "federalist-modern-team-template",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_file_locked_operation",
-          "agency": "General Services Administration",
-          "project_name": "file-locked-operation",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_atf_eregs",
-          "agency": "General Services Administration",
-          "project_name": "atf-eregs",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cf_service_proxy",
-          "agency": "General Services Administration",
-          "project_name": "cf-service-proxy",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_osbu_forecast",
-          "agency": "General Services Administration",
-          "project_name": "osbu-forecast",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cf_events",
-          "agency": "General Services Administration",
-          "project_name": "cf-events",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_lambda_map_reduce",
-          "agency": "General Services Administration",
-          "project_name": "lambda_map_reduce",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_development_guide",
-          "agency": "General Services Administration",
-          "project_name": "development-guide",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_qna",
-          "agency": "General Services Administration",
-          "project_name": "qna",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pdf_forms_tutorial",
-          "agency": "General Services Administration",
-          "project_name": "pdf-forms-tutorial",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_dolores_landingham_slack_bot",
-          "agency": "General Services Administration",
-          "project_name": "dolores-landingham-slack-bot",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_risk_management_framework",
-          "agency": "General Services Administration",
-          "project_name": "risk-management-framework",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_dol_form226_validator",
-          "agency": "General Services Administration",
-          "project_name": "dol-form226-validator",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_peacecorps_site",
-          "agency": "General Services Administration",
-          "project_name": "peacecorps-site",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_peace_corps_infrastructure",
-          "agency": "General Services Administration",
-          "project_name": "peace-corps-infrastructure",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_letgirlslearn",
-          "agency": "General Services Administration",
-          "project_name": "letgirlslearn",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_s3_proxy",
-          "agency": "General Services Administration",
-          "project_name": "cg-s3-proxy",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cf_gitaware",
-          "agency": "General Services Administration",
-          "project_name": "cf-gitaware",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_linkify_citations",
-          "agency": "General Services Administration",
-          "project_name": "linkify-citations",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_forecast",
-          "agency": "General Services Administration",
-          "project_name": "forecast",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cf_elk_proxy",
-          "agency": "General Services Administration",
-          "project_name": "cf-elk-proxy",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_joining_18f_app",
-          "agency": "General Services Administration",
-          "project_name": "joining-18f-app",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pages_server",
-          "agency": "General Services Administration",
-          "project_name": "pages-server",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_lumbergh",
-          "agency": "General Services Administration",
-          "project_name": "lumbergh",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_fec_proxy",
-          "agency": "General Services Administration",
-          "project_name": "fec-proxy",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_github_webhook_validator",
-          "agency": "General Services Administration",
-          "project_name": "github-webhook-validator",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_3d_files",
-          "agency": "General Services Administration",
-          "project_name": "3d-files",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_feedback_widget",
-          "agency": "General Services Administration",
-          "project_name": "feedback-widget",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_oauth2_proxy_authentication_gem",
-          "agency": "General Services Administration",
-          "project_name": "oauth2_proxy_authentication_gem",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_oauth2_proxy_authentication_npm",
-          "agency": "General Services Administration",
-          "project_name": "oauth2-proxy-authentication-npm",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_hmac_authentication_npm",
-          "agency": "General Services Administration",
-          "project_name": "hmac-authentication-npm",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_hmac_authentication_gem",
-          "agency": "General Services Administration",
-          "project_name": "hmac_authentication_gem",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_hmacauth",
-          "agency": "General Services Administration",
-          "project_name": "hmacauth",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_metrics",
-          "agency": "General Services Administration",
-          "project_name": "cg-metrics",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_hmacproxy",
-          "agency": "General Services Administration",
-          "project_name": "hmacproxy",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_uaa",
-          "agency": "General Services Administration",
-          "project_name": "cg-uaa",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_brand",
-          "agency": "General Services Administration",
-          "project_name": "brand",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_labor_viz",
-          "agency": "General Services Administration",
-          "project_name": "labor-viz",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_hmac_authentication_py",
-          "agency": "General Services Administration",
-          "project_name": "hmac_authentication_py",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_micropurchase",
-          "agency": "General Services Administration",
-          "project_name": "micropurchase",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_sec_gov_developer",
-          "agency": "General Services Administration",
-          "project_name": "SEC.gov-developer",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_federalist_docker_build",
-          "agency": "General Services Administration",
-          "project_name": "federalist-docker-build",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_authdelegate",
-          "agency": "General Services Administration",
-          "project_name": "authdelegate",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_code_style_guide",
-          "agency": "General Services Administration",
-          "project_name": "code-style-guide",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_devops_workshop",
-          "agency": "General Services Administration",
-          "project_name": "devops-workshop",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_authentication",
-          "agency": "General Services Administration",
-          "project_name": "authentication",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_compliancelib_python",
-          "agency": "General Services Administration",
-          "project_name": "compliancelib-python",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_team_api_server",
-          "agency": "General Services Administration",
-          "project_name": "team-api-server",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_prosemirror",
-          "agency": "General Services Administration",
-          "project_name": "prosemirror",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_wg_agiledesign",
-          "agency": "General Services Administration",
-          "project_name": "wg-agiledesign",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_glossary",
-          "agency": "General Services Administration",
-          "project_name": "glossary",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_micropurchase_temp",
-          "agency": "General Services Administration",
-          "project_name": "micropurchase-temp",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_partnership_playbook",
-          "agency": "General Services Administration",
-          "project_name": "partnership-playbook",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_handbook_urls",
-          "agency": "General Services Administration",
-          "project_name": "handbook-urls",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_web_design_standards_drupal",
-          "agency": "General Services Administration",
-          "project_name": "web-design-standards-drupal",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_us_web_design_standards_gem",
-          "agency": "General Services Administration",
-          "project_name": "us_web_design_standards_gem",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_sandbox_bot",
-          "agency": "General Services Administration",
-          "project_name": "cg-sandbox-bot",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_federalist_builder",
-          "agency": "General Services Administration",
-          "project_name": "federalist-builder",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_confidential_survey",
-          "agency": "General Services Administration",
-          "project_name": "confidential-survey",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_sheet_to_csv",
-          "agency": "General Services Administration",
-          "project_name": "sheet-to-csv",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_infrastructure_modernization",
-          "agency": "General Services Administration",
-          "project_name": "infrastructure-modernization",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_gapps_download",
-          "agency": "General Services Administration",
-          "project_name": "gapps-download",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_frstack",
-          "agency": "General Services Administration",
-          "project_name": "frstack",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_compliance",
-          "agency": "General Services Administration",
-          "project_name": "cg-compliance",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_wg_api",
-          "agency": "General Services Administration",
-          "project_name": "wg-api",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_release",
-          "agency": "General Services Administration",
-          "project_name": "cg-release",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_onboarding_documents",
-          "agency": "General Services Administration",
-          "project_name": "onboarding-documents",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_emoji_search",
-          "agency": "General Services Administration",
-          "project_name": "emoji_search",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_digital_team_playbook",
-          "agency": "General Services Administration",
-          "project_name": "digital-team-playbook",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_death_star",
-          "agency": "General Services Administration",
-          "project_name": "death-star",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_minion_nessus_plugin",
-          "agency": "General Services Administration",
-          "project_name": "minion-nessus-plugin",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_stats_scripts",
-          "agency": "General Services Administration",
-          "project_name": "cg-stats-scripts",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_discussions",
-          "agency": "General Services Administration",
-          "project_name": "discussions",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_dev_environment_standardization",
-          "agency": "General Services Administration",
-          "project_name": "dev-environment-standardization",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_g_content",
-          "agency": "General Services Administration",
-          "project_name": "g-content",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_discover_our_work",
-          "agency": "General Services Administration",
-          "project_name": "discover-our-work",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_wg_diversity",
-          "agency": "General Services Administration",
-          "project_name": "wg-diversity",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_wg_dataservices",
-          "agency": "General Services Administration",
-          "project_name": "wg-dataservices",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_angrytock",
-          "agency": "General Services Administration",
-          "project_name": "angrytock",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_pipelines",
-          "agency": "General Services Administration",
-          "project_name": "cg-pipelines",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_discourse",
-          "agency": "General Services Administration",
-          "project_name": "discourse",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_compliance_toolkit",
-          "agency": "General Services Administration",
-          "project_name": "compliance-toolkit",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_minion_vm",
-          "agency": "General Services Administration",
-          "project_name": "minion-vm",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_accordion",
-          "agency": "General Services Administration",
-          "project_name": "accordion",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_docker_ruby_ubuntu",
-          "agency": "General Services Administration",
-          "project_name": "docker-ruby-ubuntu",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_about_yml_validator",
-          "agency": "General Services Administration",
-          "project_name": "about-yml-validator",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_feedback_js",
-          "agency": "General Services Administration",
-          "project_name": "feedback.js",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_zap_core_help",
-          "agency": "General Services Administration",
-          "project_name": "zap-core-help",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_github_issue_lifecycle",
-          "agency": "General Services Administration",
-          "project_name": "github-issue-lifecycle",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_how_to_deploy",
-          "agency": "General Services Administration",
-          "project_name": "how-to-deploy",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_id_wireframe",
-          "agency": "General Services Administration",
-          "project_name": "id_wireframe",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_wg_volunteer",
-          "agency": "General Services Administration",
-          "project_name": "wg-volunteer",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cf_ex_wordpress",
-          "agency": "General Services Administration",
-          "project_name": "cf-ex-wordpress",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_proto_lei",
-          "agency": "General Services Administration",
-          "project_name": "proto-lei",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_wordpress_heroku",
-          "agency": "General Services Administration",
-          "project_name": "wordpress-heroku",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_hubot_slack_github_issues",
-          "agency": "General Services Administration",
-          "project_name": "hubot-slack-github-issues",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_unit_testing_node",
-          "agency": "General Services Administration",
-          "project_name": "unit-testing-node",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_staytus",
-          "agency": "General Services Administration",
-          "project_name": "staytus",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_fec_eregs",
-          "agency": "General Services Administration",
-          "project_name": "fec-eregs",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cf_ex_drupal",
-          "agency": "General Services Administration",
-          "project_name": "cf-ex-drupal",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cf_go_cron",
-          "agency": "General Services Administration",
-          "project_name": "cf-go-cron",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_navy",
-          "agency": "General Services Administration",
-          "project_name": "Navy",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_node_slack_client",
-          "agency": "General Services Administration",
-          "project_name": "node-slack-client",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_hubot_adapter_slack_bot",
-          "agency": "General Services Administration",
-          "project_name": "hubot-adapter-slack-bot",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_checklistomania",
-          "agency": "General Services Administration",
-          "project_name": "checklistomania",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_product_guide",
-          "agency": "General Services Administration",
-          "project_name": "product-guide",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_aws_broker",
-          "agency": "General Services Administration",
-          "project_name": "aws-broker",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_federalist_docs",
-          "agency": "General Services Administration",
-          "project_name": "federalist-docs",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_openopps_docs",
-          "agency": "General Services Administration",
-          "project_name": "openopps-docs",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_samwise",
-          "agency": "General Services Administration",
-          "project_name": "samwise",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_ca_child_welfare_solicitations",
-          "agency": "General Services Administration",
-          "project_name": "ca-child-welfare-solicitations",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_concourse_compliance_testing",
-          "agency": "General Services Administration",
-          "project_name": "concourse-compliance-testing",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_objectives_key_results",
-          "agency": "General Services Administration",
-          "project_name": "objectives-and-key-results",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_engineering_team_faq",
-          "agency": "General Services Administration",
-          "project_name": "engineering-team-faq",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_blogging_guide",
-          "agency": "General Services Administration",
-          "project_name": "blogging-guide",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_fpds_getter",
-          "agency": "General Services Administration",
-          "project_name": "fpds-getter",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_test_repo",
-          "agency": "General Services Administration",
-          "project_name": "test-repo",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_style",
-          "agency": "General Services Administration",
-          "project_name": "cg-style",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_bosh_deployment_resource",
-          "agency": "General Services Administration",
-          "project_name": "bosh-deployment-resource",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_kibana_cf_authentication",
-          "agency": "General Services Administration",
-          "project_name": "kibana-cf_authentication",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_elasticsearch_rails_ha_gem",
-          "agency": "General Services Administration",
-          "project_name": "elasticsearch-rails-ha-gem",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_logsearch_for_cloudfoundry",
-          "agency": "General Services Administration",
-          "project_name": "logsearch-for-cloudfoundry",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_private_eye",
-          "agency": "General Services Administration",
-          "project_name": "private-eye",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_edu_measure_content",
-          "agency": "General Services Administration",
-          "project_name": "edu-measure-content",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_federalist_design",
-          "agency": "General Services Administration",
-          "project_name": "federalist-design",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_edu_voice_tone",
-          "agency": "General Services Administration",
-          "project_name": "edu-voice-and-tone",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_micropurchasedata",
-          "agency": "General Services Administration",
-          "project_name": "micropurchasedata",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pa11y_crawl",
-          "agency": "General Services Administration",
-          "project_name": "pa11y-crawl",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_wg_onboarding",
-          "agency": "General Services Administration",
-          "project_name": "wg-onboarding",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_wg_identity",
-          "agency": "General Services Administration",
-          "project_name": "wg-identity",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_security_group_test_app",
-          "agency": "General Services Administration",
-          "project_name": "security-group-test-app",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_trello_card_velocity",
-          "agency": "General Services Administration",
-          "project_name": "trello-card-velocity",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_json_editor",
-          "agency": "General Services Administration",
-          "project_name": "json-editor",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_beta_18f_gov",
-          "agency": "General Services Administration",
-          "project_name": "beta.18f.gov",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_ffd_toolkit",
-          "agency": "General Services Administration",
-          "project_name": "ffd-toolkit",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_auctioneer",
-          "agency": "General Services Administration",
-          "project_name": "auctioneer",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_contracting_cookbook_client",
-          "agency": "General Services Administration",
-          "project_name": "contracting-cookbook-client",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_18f_cli",
-          "agency": "General Services Administration",
-          "project_name": "18f-cli",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_identity_idp",
-          "agency": "General Services Administration",
-          "project_name": "identity-idp",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cf_abacus",
-          "agency": "General Services Administration",
-          "project_name": "cf-abacus",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_caddy_boshrelease",
-          "agency": "General Services Administration",
-          "project_name": "caddy-boshrelease",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_micropurchase_api_docs",
-          "agency": "General Services Administration",
-          "project_name": "micropurchase-api-docs",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_about_yml_editor",
-          "agency": "General Services Administration",
-          "project_name": "about-yml-editor",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_federalist_build_js",
-          "agency": "General Services Administration",
-          "project_name": "federalist-build-js",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_notalone_backup",
-          "agency": "General Services Administration",
-          "project_name": "notalone-backup",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_c2_master_detail",
-          "agency": "General Services Administration",
-          "project_name": "c2-master-detail",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_karass",
-          "agency": "General Services Administration",
-          "project_name": "karass",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_singlepaged",
-          "agency": "General Services Administration",
-          "project_name": "SinglePaged",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_micropurchase_deck",
-          "agency": "General Services Administration",
-          "project_name": "micropurchase-deck",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_node_1",
-          "agency": "General Services Administration",
-          "project_name": "node-1",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_presidential_innovation_foundation_github_io",
-          "agency": "General Services Administration",
-          "project_name": "presidential-innovation-foundation.github.io",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_fedramp_data",
-          "agency": "General Services Administration",
-          "project_name": "fedramp-data",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_compliance_docs",
-          "agency": "General Services Administration",
-          "project_name": "compliance-docs",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_lunr_server",
-          "agency": "General Services Administration",
-          "project_name": "lunr-server",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_circle_wdio_federalist",
-          "agency": "General Services Administration",
-          "project_name": "circle-wdio-federalist",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_plain_language_tutorial",
-          "agency": "General Services Administration",
-          "project_name": "plain-language-tutorial",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_internal_air_traffic_control",
-          "agency": "General Services Administration",
-          "project_name": "internal-air-traffic-control",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_bpa_trello",
-          "agency": "General Services Administration",
-          "project_name": "bpa-trello",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_analytics_reporter_example",
-          "agency": "General Services Administration",
-          "project_name": "analytics-reporter-example",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_style_gem",
-          "agency": "General Services Administration",
-          "project_name": "cg-style-gem",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_c2_redirect",
-          "agency": "General Services Administration",
-          "project_name": "c2-redirect",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_passport_google_oauth2",
-          "agency": "General Services Administration",
-          "project_name": "passport-google-oauth2",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_fpki_testing",
-          "agency": "General Services Administration",
-          "project_name": "fpki-testing",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_slack_notification_resource_boshrelease",
-          "agency": "General Services Administration",
-          "project_name": "slack-notification-resource-boshrelease",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_deploy_concourse_docker_image",
-          "agency": "General Services Administration",
-          "project_name": "cg-deploy-concourse-docker-image",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_node_restify",
-          "agency": "General Services Administration",
-          "project_name": "node-restify",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_compliance_viewer",
-          "agency": "General Services Administration",
-          "project_name": "compliance-viewer",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_goshin",
-          "agency": "General Services Administration",
-          "project_name": "cg-goshin",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_deploy_compliance_documentation",
-          "agency": "General Services Administration",
-          "project_name": "cg-deploy-compliance-documentation",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_epa_notice",
-          "agency": "General Services Administration",
-          "project_name": "epa-notice",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_pipeline_tasks",
-          "agency": "General Services Administration",
-          "project_name": "cg-pipeline-tasks",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_ffd_microsite",
-          "agency": "General Services Administration",
-          "project_name": "ffd-microsite",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_standup_slack_bot",
-          "agency": "General Services Administration",
-          "project_name": "standup-slack-bot",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_deploy_monitoring",
-          "agency": "General Services Administration",
-          "project_name": "cg-deploy-monitoring",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_deploy_concourse",
-          "agency": "General Services Administration",
-          "project_name": "cg-deploy-concourse",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_npm_bootstrap",
-          "agency": "General Services Administration",
-          "project_name": "npm-bootstrap",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_grafana_boshrelease",
-          "agency": "General Services Administration",
-          "project_name": "cg-grafana-boshrelease",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_deploy_cf",
-          "agency": "General Services Administration",
-          "project_name": "cg-deploy-cf",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_influxdb_boshrelease",
-          "agency": "General Services Administration",
-          "project_name": "cg-influxdb-boshrelease",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_team_browser",
-          "agency": "General Services Administration",
-          "project_name": "team-browser",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_deploy_discourse",
-          "agency": "General Services Administration",
-          "project_name": "cg-deploy-discourse",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_products_platforms",
-          "agency": "General Services Administration",
-          "project_name": "products-platforms",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_knowledge_sharing_toolkit",
-          "agency": "General Services Administration",
-          "project_name": "knowledge-sharing-toolkit",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_collectd_boshrelease",
-          "agency": "General Services Administration",
-          "project_name": "cg-collectd-boshrelease",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_mocha_casperjs",
-          "agency": "General Services Administration",
-          "project_name": "mocha-casperjs",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_travel_form",
-          "agency": "General Services Administration",
-          "project_name": "travel-form",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_deduplicate_tock_float",
-          "agency": "General Services Administration",
-          "project_name": "deduplicate-tock-float",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pa11y_rails",
-          "agency": "General Services Administration",
-          "project_name": "pa11y-rails",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_huginn",
-          "agency": "General Services Administration",
-          "project_name": "huginn",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_elasticsearch_indexstager_gem",
-          "agency": "General Services Administration",
-          "project_name": "elasticsearch-indexstager-gem",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_common_resource",
-          "agency": "General Services Administration",
-          "project_name": "cg-common-resource",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_us_federal_holidays",
-          "agency": "General Services Administration",
-          "project_name": "us-federal-holidays",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_onena",
-          "agency": "General Services Administration",
-          "project_name": "onena",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_deploy_logsearch",
-          "agency": "General Services Administration",
-          "project_name": "cg-deploy-logsearch",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_videochat_mute_manager",
-          "agency": "General Services Administration",
-          "project_name": "videochat-mute-manager",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_drmaas",
-          "agency": "General Services Administration",
-          "project_name": "drmaas",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_influxdb_firehose_nozzle",
-          "agency": "General Services Administration",
-          "project_name": "influxdb-firehose-nozzle",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_influxdb_firehose_nozzle_release",
-          "agency": "General Services Administration",
-          "project_name": "influxdb-firehose-nozzle-release",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_seal",
-          "agency": "General Services Administration",
-          "project_name": "seal",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_postmortems",
-          "agency": "General Services Administration",
-          "project_name": "cg-postmortems",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_coffeemate",
-          "agency": "General Services Administration",
-          "project_name": "coffeemate",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_s3_service_broker",
-          "agency": "General Services Administration",
-          "project_name": "cg-s3-service-broker",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_riemann_boshrelease",
-          "agency": "General Services Administration",
-          "project_name": "cg-riemann-boshrelease",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_climate_labs",
-          "agency": "General Services Administration",
-          "project_name": "climate-labs",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_joining_epa",
-          "agency": "General Services Administration",
-          "project_name": "joining-epa",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_s3_resource_simple",
-          "agency": "General Services Administration",
-          "project_name": "s3-resource-simple",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_bpa_fedramp_dashboard",
-          "agency": "General Services Administration",
-          "project_name": "bpa-fedramp-dashboard",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_concourse_http_api_resource",
-          "agency": "General Services Administration",
-          "project_name": "concourse-http-api-resource",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_deploy_admin_ui",
-          "agency": "General Services Administration",
-          "project_name": "cg-deploy-admin-ui",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pages_shell",
-          "agency": "General Services Administration",
-          "project_name": "pages-shell",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_fec_cloud",
-          "agency": "General Services Administration",
-          "project_name": "fec-cloud",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pulse_accessibility_data",
-          "agency": "General Services Administration",
-          "project_name": "pulse-accessibility-data",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_deploy_influxdb_firehose_nozzle",
-          "agency": "General Services Administration",
-          "project_name": "cg-deploy-influxdb-firehose-nozzle",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_deploy_bosh",
-          "agency": "General Services Administration",
-          "project_name": "cg-deploy-bosh",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_hub_v2",
-          "agency": "General Services Administration",
-          "project_name": "hub-v2",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_heroku_buildpack_apt",
-          "agency": "General Services Administration",
-          "project_name": "heroku-buildpack-apt",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_public_comments",
-          "agency": "General Services Administration",
-          "project_name": "public-comments",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_transformation_services",
-          "agency": "General Services Administration",
-          "project_name": "transformation-services",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_writing_lab_guide",
-          "agency": "General Services Administration",
-          "project_name": "writing-lab-guide",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_ntis_data_services_project",
-          "agency": "General Services Administration",
-          "project_name": "NTIS-Data-Services-Project",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_atc_trello",
-          "agency": "General Services Administration",
-          "project_name": "atc-trello",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_meta",
-          "agency": "General Services Administration",
-          "project_name": "meta",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_concourse_http_resource",
-          "agency": "General Services Administration",
-          "project_name": "concourse-http-resource",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_nessus_agent_boshrelease",
-          "agency": "General Services Administration",
-          "project_name": "cg-nessus-agent-boshrelease",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pdfhook",
-          "agency": "General Services Administration",
-          "project_name": "pdfhook",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_hubot_scripts_us_federal_holiday",
-          "agency": "General Services Administration",
-          "project_name": "hubot-scripts-us-federal-holiday",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pa11y_reporter_full_json",
-          "agency": "General Services Administration",
-          "project_name": "pa11y-reporter-full-json",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_htsql_docker",
-          "agency": "General Services Administration",
-          "project_name": "htsql-docker",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_14c_prototype",
-          "agency": "General Services Administration",
-          "project_name": "14c-prototype",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_gh_traffic",
-          "agency": "General Services Administration",
-          "project_name": "gh-traffic",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_sandman2",
-          "agency": "General Services Administration",
-          "project_name": "sandman2",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_ogp_payroll",
-          "agency": "General Services Administration",
-          "project_name": "ogp-payroll",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_ogp_payroll_server",
-          "agency": "General Services Administration",
-          "project_name": "ogp-payroll-server",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_product",
-          "agency": "General Services Administration",
-          "project_name": "cg-product",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pa11y_docker",
-          "agency": "General Services Administration",
-          "project_name": "pa11y-docker",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_ntis_gov",
-          "agency": "General Services Administration",
-          "project_name": "ntis-gov",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_c2_api_client_ruby",
-          "agency": "General Services Administration",
-          "project_name": "c2-api-client-ruby",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_chat",
-          "agency": "General Services Administration",
-          "project_name": "chat",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_application_ssp_example",
-          "agency": "General Services Administration",
-          "project_name": "cg-application-ssp-example",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_rugged_devops",
-          "agency": "General Services Administration",
-          "project_name": "rugged-devops",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_strategy",
-          "agency": "General Services Administration",
-          "project_name": "strategy",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_acq_templates",
-          "agency": "General Services Administration",
-          "project_name": "acq-templates",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cap_api_docker",
-          "agency": "General Services Administration",
-          "project_name": "cap-api-docker",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_gsa_certifications",
-          "agency": "General Services Administration",
-          "project_name": "GSA-Certifications",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_atlas",
-          "agency": "General Services Administration",
-          "project_name": "cg-atlas",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_trello_webhook_server",
-          "agency": "General Services Administration",
-          "project_name": "trello-webhook-server",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_wds_ia_summit_presentation",
-          "agency": "General Services Administration",
-          "project_name": "wds-ia-summit-presentation",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_chandika",
-          "agency": "General Services Administration",
-          "project_name": "chandika",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_django_pg_fts",
-          "agency": "General Services Administration",
-          "project_name": "django-pg-fts",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_identity_idv",
-          "agency": "General Services Administration",
-          "project_name": "identity-idv",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_legalese",
-          "agency": "General Services Administration",
-          "project_name": "legalese",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cfpb_eprocurement",
-          "agency": "General Services Administration",
-          "project_name": "cfpb-eprocurement",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_ossec_boshrelease",
-          "agency": "General Services Administration",
-          "project_name": "cg-ossec-boshrelease",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_template_form",
-          "agency": "General Services Administration",
-          "project_name": "template-form",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cf_env_parser_buildpack",
-          "agency": "General Services Administration",
-          "project_name": "cf-env-parser-buildpack",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_identity_sp_sinatra",
-          "agency": "General Services Administration",
-          "project_name": "identity-sp-sinatra",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_microviz",
-          "agency": "General Services Administration",
-          "project_name": "microviz",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_bayeshack_interior",
-          "agency": "General Services Administration",
-          "project_name": "bayeshack-interior",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_vote_gov",
-          "agency": "General Services Administration",
-          "project_name": "vote-gov",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_frontend_slides",
-          "agency": "General Services Administration",
-          "project_name": "frontend-slides",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_retext_18f",
-          "agency": "General Services Administration",
-          "project_name": "retext-18f",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_tripwire_boshrelease",
-          "agency": "General Services Administration",
-          "project_name": "cg-tripwire-boshrelease",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_golang_workshop_irl_2016",
-          "agency": "General Services Administration",
-          "project_name": "golang_workshop_irl_2016",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_e_manifest_spring",
-          "agency": "General Services Administration",
-          "project_name": "e-manifest-spring",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_openopps_design",
-          "agency": "General Services Administration",
-          "project_name": "openopps-design",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_deck_docker_images",
-          "agency": "General Services Administration",
-          "project_name": "cg-deck-docker-images",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_uaa_release",
-          "agency": "General Services Administration",
-          "project_name": "cg-uaa-release",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_bug_bounty",
-          "agency": "General Services Administration",
-          "project_name": "bug-bounty",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_uaa_extras",
-          "agency": "General Services Administration",
-          "project_name": "cg-uaa-extras",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_acq_trello_listener",
-          "agency": "General Services Administration",
-          "project_name": "acq-trello-listener",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_projects",
-          "agency": "General Services Administration",
-          "project_name": "projects",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_provision",
-          "agency": "General Services Administration",
-          "project_name": "cg-provision",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_identity_dashboard",
-          "agency": "General Services Administration",
-          "project_name": "identity-dashboard",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_transformation_research",
-          "agency": "General Services Administration",
-          "project_name": "transformation-research",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_humans_18f",
-          "agency": "General Services Administration",
-          "project_name": "humans-of-18f",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_agent_q",
-          "agency": "General Services Administration",
-          "project_name": "cg-agent-q",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_encrypt_blobstore_boshrelease",
-          "agency": "General Services Administration",
-          "project_name": "cg-encrypt-blobstore-boshrelease",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_login_gov_developer_documentation",
-          "agency": "General Services Administration",
-          "project_name": "Login.gov-developer-documentation",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_innovation_toolkit_demo",
-          "agency": "General Services Administration",
-          "project_name": "innovation-toolkit-demo",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cf_cdn_service_broker",
-          "agency": "General Services Administration",
-          "project_name": "cf-cdn-service-broker",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_onepage_opensource",
-          "agency": "General Services Administration",
-          "project_name": "onepage-opensource",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_runpa11yscans",
-          "agency": "General Services Administration",
-          "project_name": "runPa11yScans",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_identity_dev_docs",
-          "agency": "General Services Administration",
-          "project_name": "identity-dev-docs",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_design",
-          "agency": "General Services Administration",
-          "project_name": "cg-design",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_raktabija",
-          "agency": "General Services Administration",
-          "project_name": "raktabija",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_bootstrap_concourse_ami",
-          "agency": "General Services Administration",
-          "project_name": "cg-bootstrap-concourse-ami",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_svg4everybody",
-          "agency": "General Services Administration",
-          "project_name": "svg4everybody",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_stylelint_rules",
-          "agency": "General Services Administration",
-          "project_name": "stylelint-rules",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_web_design_standards_ux",
-          "agency": "General Services Administration",
-          "project_name": "web-design-standards-ux",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pa11y_lambda",
-          "agency": "General Services Administration",
-          "project_name": "pa11y-lambda",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_awslogs_boshrelease",
-          "agency": "General Services Administration",
-          "project_name": "cg-awslogs-boshrelease",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_vote_gov_ux",
-          "agency": "General Services Administration",
-          "project_name": "vote-gov-ux",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_openopps_platform",
-          "agency": "General Services Administration",
-          "project_name": "openopps-platform",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pa11y_lambda_cluster",
-          "agency": "General Services Administration",
-          "project_name": "pa11y-lambda-cluster",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_botkit",
-          "agency": "General Services Administration",
-          "project_name": "botkit",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_project_planner",
-          "agency": "General Services Administration",
-          "project_name": "project-planner",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_dotgov_list_node",
-          "agency": "General Services Administration",
-          "project_name": "dotgov-list-node",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_wg_security",
-          "agency": "General Services Administration",
-          "project_name": "wg-security",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_18f_reveal_js_theme",
-          "agency": "General Services Administration",
-          "project_name": "18f-reveal.js-theme",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_concourse_pipeline_resource",
-          "agency": "General Services Administration",
-          "project_name": "concourse-pipeline-resource",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_deploy_bots",
-          "agency": "General Services Administration",
-          "project_name": "cg-deploy-bots",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_acqstackdb",
-          "agency": "General Services Administration",
-          "project_name": "acqstackdb",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_deploy_docker_swarm",
-          "agency": "General Services Administration",
-          "project_name": "cg-deploy-docker-swarm",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_request_circuit",
-          "agency": "General Services Administration",
-          "project_name": "request-circuit",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_identity_sp_rails",
-          "agency": "General Services Administration",
-          "project_name": "identity-sp-rails",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_admin_ui_boshrelease",
-          "agency": "General Services Administration",
-          "project_name": "admin-ui-boshrelease",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_html_proofer_docker",
-          "agency": "General Services Administration",
-          "project_name": "html-proofer-docker",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_sslyze_docker",
-          "agency": "General Services Administration",
-          "project_name": "sslyze-docker",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_phantomas_docker",
-          "agency": "General Services Administration",
-          "project_name": "phantomas-docker",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_site_inspector_docker",
-          "agency": "General Services Administration",
-          "project_name": "site-inspector-docker",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_clamav_boshrelease",
-          "agency": "General Services Administration",
-          "project_name": "cg-clamav-boshrelease",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_security_disclosures",
-          "agency": "General Services Administration",
-          "project_name": "security-disclosures",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_nessus_manager_boshrelease",
-          "agency": "General Services Administration",
-          "project_name": "cg-nessus-manager-boshrelease",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_identity_proofer_gem",
-          "agency": "General Services Administration",
-          "project_name": "identity-proofer-gem",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_deploy_nessus_manager",
-          "agency": "General Services Administration",
-          "project_name": "cg-deploy-nessus-manager",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_riemannc_boshrelease",
-          "agency": "General Services Administration",
-          "project_name": "cg-riemannc-boshrelease",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_firehose_to_syslog",
-          "agency": "General Services Administration",
-          "project_name": "firehose-to-syslog",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_digitalaccelerator",
-          "agency": "General Services Administration",
-          "project_name": "digitalaccelerator",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_newrelic_boshrelease",
-          "agency": "General Services Administration",
-          "project_name": "cg-newrelic-boshrelease",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_fedramp_dashboard",
-          "agency": "General Services Administration",
-          "project_name": "fedramp-dashboard",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_eregs_platform",
-          "agency": "General Services Administration",
-          "project_name": "eregs-platform",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_ed_api_program",
-          "agency": "General Services Administration",
-          "project_name": "ED-API-Program",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_state_faq",
-          "agency": "General Services Administration",
-          "project_name": "state-faq",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_s3_encryptor",
-          "agency": "General Services Administration",
-          "project_name": "s3-encryptor",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_acquisitions",
-          "agency": "General Services Administration",
-          "project_name": "acquisitions",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_snort_boshrelease",
-          "agency": "General Services Administration",
-          "project_name": "cg-snort-boshrelease",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_bpa_dol_whd_14_c",
-          "agency": "General Services Administration",
-          "project_name": "bpa-DOL-WHD-14-c",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_fec_transition",
-          "agency": "General Services Administration",
-          "project_name": "fec-transition",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_acq_templates_from_trello",
-          "agency": "General Services Administration",
-          "project_name": "acq-templates-from-trello",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_fec_shipper",
-          "agency": "General Services Administration",
-          "project_name": "fec-shipper",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_reheader",
-          "agency": "General Services Administration",
-          "project_name": "reheader",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cookiecutter_pypackage",
-          "agency": "General Services Administration",
-          "project_name": "cookiecutter-pypackage",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_trello_utils",
-          "agency": "General Services Administration",
-          "project_name": "trello_utils",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_identity_sp_python",
-          "agency": "General Services Administration",
-          "project_name": "identity-sp-python",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_talent_reporting_product",
-          "agency": "General Services Administration",
-          "project_name": "talent-reporting-product",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_digital_acquisition_playbook",
-          "agency": "General Services Administration",
-          "project_name": "digital-acquisition-playbook",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_tock_blocks",
-          "agency": "General Services Administration",
-          "project_name": "tock-blocks",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_clone_army",
-          "agency": "General Services Administration",
-          "project_name": "clone_army",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_deploy_diego",
-          "agency": "General Services Administration",
-          "project_name": "cg-deploy-diego",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_dns",
-          "agency": "General Services Administration",
-          "project_name": "dns",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_react_redux_event_demo",
-          "agency": "General Services Administration",
-          "project_name": "react-redux-event-demo",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_bpa_identity_management",
-          "agency": "General Services Administration",
-          "project_name": "bpa-identity-management",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_paper_rhino",
-          "agency": "General Services Administration",
-          "project_name": "paper-rhino",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_fake_uaa",
-          "agency": "General Services Administration",
-          "project_name": "cg-fake-uaa",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cf_app_events_logger",
-          "agency": "General Services Administration",
-          "project_name": "cf-app-events-logger",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_django_admin508",
-          "agency": "General Services Administration",
-          "project_name": "django-admin508",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_gov_repo_langs",
-          "agency": "General Services Administration",
-          "project_name": "gov-repo-langs",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_hhs_acf_uc_api",
-          "agency": "General Services Administration",
-          "project_name": "hhs-acf-uc-api",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_hhs_acf_uc_dashboard",
-          "agency": "General Services Administration",
-          "project_name": "hhs-acf-uc-dashboard",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cookiecutter_django",
-          "agency": "General Services Administration",
-          "project_name": "cookiecutter-django",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_allregs",
-          "agency": "General Services Administration",
-          "project_name": "allregs",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_18f_education_discovery",
-          "agency": "General Services Administration",
-          "project_name": "18f-education-discovery",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cf_example_suitecrm",
-          "agency": "General Services Administration",
-          "project_name": "cf-example-suitecrm",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_rdbms_anonymizer",
-          "agency": "General Services Administration",
-          "project_name": "rdbms_anonymizer",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_web_design_standards_docs",
-          "agency": "General Services Administration",
-          "project_name": "web-design-standards-docs",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_quick_stats",
-          "agency": "General Services Administration",
-          "project_name": "quick-stats",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_marigold",
-          "agency": "General Services Administration",
-          "project_name": "marigold",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_bpa_opm_eqip",
-          "agency": "General Services Administration",
-          "project_name": "bpa-opm-eqip",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_markov_bot",
-          "agency": "General Services Administration",
-          "project_name": "markov_bot",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_dynamoed",
-          "agency": "General Services Administration",
-          "project_name": "dynamoed",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_riemann_firehose_nozzle",
-          "agency": "General Services Administration",
-          "project_name": "riemann-firehose-nozzle",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_uswds_rails_gem",
-          "agency": "General Services Administration",
-          "project_name": "uswds-rails-gem",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_deploy_riemann_firehose_nozzle",
-          "agency": "General Services Administration",
-          "project_name": "cg-deploy-riemann-firehose-nozzle",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_kubernetes_release",
-          "agency": "General Services Administration",
-          "project_name": "kubernetes-release",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_bosh_log_forwarder_boshrelease",
-          "agency": "General Services Administration",
-          "project_name": "bosh-log-forwarder-boshrelease",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_felt_sass",
-          "agency": "General Services Administration",
-          "project_name": "felt-sass",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_felt_recipe_18f",
-          "agency": "General Services Administration",
-          "project_name": "felt-recipe-18F",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_dcoi_recommendations",
-          "agency": "General Services Administration",
-          "project_name": "DCOI-recommendations",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_deploy_kubernetes",
-          "agency": "General Services Administration",
-          "project_name": "cg-deploy-kubernetes",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_share",
-          "agency": "General Services Administration",
-          "project_name": "share",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_kubernetes_broker",
-          "agency": "General Services Administration",
-          "project_name": "kubernetes-broker",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_identity_intro",
-          "agency": "General Services Administration",
-          "project_name": "identity-intro",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_saml_idp",
-          "agency": "General Services Administration",
-          "project_name": "saml_idp",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_workshops_lab",
-          "agency": "General Services Administration",
-          "project_name": "workshops-lab",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_federalist_landing_page_template",
-          "agency": "General Services Administration",
-          "project_name": "federalist-landing-page-template",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_wg_legacy_systems",
-          "agency": "General Services Administration",
-          "project_name": "wg-legacy-systems",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_kube2consul",
-          "agency": "General Services Administration",
-          "project_name": "kube2consul",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_migration_bot",
-          "agency": "General Services Administration",
-          "project_name": "cg-migration-bot",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_generator_18f_static",
-          "agency": "General Services Administration",
-          "project_name": "generator-18F-static",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_fec_epics",
-          "agency": "General Services Administration",
-          "project_name": "fec-epics",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_omniauth_cg",
-          "agency": "General Services Administration",
-          "project_name": "omniauth-cg",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_identity_playbook",
-          "agency": "General Services Administration",
-          "project_name": "identity-playbook",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_shibboleth_boshrelease",
-          "agency": "General Services Administration",
-          "project_name": "shibboleth-boshrelease",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_azure_sandbox",
-          "agency": "General Services Administration",
-          "project_name": "azure-sandbox",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_apd_demo",
-          "agency": "General Services Administration",
-          "project_name": "apd-demo",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_crime_data_api",
-          "agency": "General Services Administration",
-          "project_name": "crime-data-api",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_diagrams",
-          "agency": "General Services Administration",
-          "project_name": "cg-diagrams",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_fec_efiling",
-          "agency": "General Services Administration",
-          "project_name": "fec-efiling",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_sast_docker_image",
-          "agency": "General Services Administration",
-          "project_name": "cg-sast-docker-image",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_forest_service_prototype",
-          "agency": "General Services Administration",
-          "project_name": "forest-service-prototype",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_dol_whd_14c",
-          "agency": "General Services Administration",
-          "project_name": "dol-whd-14c",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_guides_router",
-          "agency": "General Services Administration",
-          "project_name": "guides-router",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_census_similarity",
-          "agency": "General Services Administration",
-          "project_name": "census-similarity",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_deploy_aws_light_stemcell_builder",
-          "agency": "General Services Administration",
-          "project_name": "cg-deploy-aws-light-stemcell-builder",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_modular_contracting_agile_development",
-          "agency": "General Services Administration",
-          "project_name": "Modular-Contracting-And-Agile-Development",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_devise_encryptable",
-          "agency": "General Services Administration",
-          "project_name": "devise-encryptable",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_handbook",
-          "agency": "General Services Administration",
-          "project_name": "handbook",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_coming_attractions",
-          "agency": "General Services Administration",
-          "project_name": "coming-attractions",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_ffd_info_exchange",
-          "agency": "General Services Administration",
-          "project_name": "ffd-info-exchange",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_politespace",
-          "agency": "General Services Administration",
-          "project_name": "politespace",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_identity_deed",
-          "agency": "General Services Administration",
-          "project_name": "identity-deed",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_fec_testing",
-          "agency": "General Services Administration",
-          "project_name": "fec-testing",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_ci",
-          "agency": "General Services Administration",
-          "project_name": "ci",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_identity_usability_testing",
-          "agency": "General Services Administration",
-          "project_name": "identity-usability-testing",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_continua11y_dashboard",
-          "agency": "General Services Administration",
-          "project_name": "continua11y-dashboard",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_deploy_shibboleth",
-          "agency": "General Services Administration",
-          "project_name": "cg-deploy-shibboleth",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_epa_notice_landing",
-          "agency": "General Services Administration",
-          "project_name": "epa-notice-landing",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_jekyll_archives",
-          "agency": "General Services Administration",
-          "project_name": "jekyll-archives",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pycel",
-          "agency": "General Services Administration",
-          "project_name": "pycel",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_informed_consent_form",
-          "agency": "General Services Administration",
-          "project_name": "informed-consent-form",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_deploy_abacus",
-          "agency": "General Services Administration",
-          "project_name": "cg-deploy-abacus",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_node_continua11y_acceptance",
-          "agency": "General Services Administration",
-          "project_name": "node-continua11y-acceptance",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_influxdb_monitor",
-          "agency": "General Services Administration",
-          "project_name": "influxdb-monitor",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_doi_digital_services_pia_ux",
-          "agency": "General Services Administration",
-          "project_name": "DOI-Digital-Services-PIA-UX",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_node_continua11y_ci_reporter",
-          "agency": "General Services Administration",
-          "project_name": "node-continua11y-ci-reporter",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_logstash_output_s3_backport_release",
-          "agency": "General Services Administration",
-          "project_name": "cg-logstash-output-s3-backport-release",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_shibboleth_idp3_totp_auth",
-          "agency": "General Services Administration",
-          "project_name": "Shibboleth-IdP3-TOTP-Auth",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cron_boshrelease",
-          "agency": "General Services Administration",
-          "project_name": "cron-boshrelease",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cf_buildpack_db_export",
-          "agency": "General Services Administration",
-          "project_name": "cf-buildpack-db-export",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_migrate_db",
-          "agency": "General Services Administration",
-          "project_name": "cg-migrate-db",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_identity_style_guide",
-          "agency": "General Services Administration",
-          "project_name": "identity-style-guide",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_vulnerability_disclosure_policy",
-          "agency": "General Services Administration",
-          "project_name": "vulnerability-disclosure-policy",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_fec_pattern_library",
-          "agency": "General Services Administration",
-          "project_name": "fec-pattern-library",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_tock_management_reports",
-          "agency": "General Services Administration",
-          "project_name": "tock-management-reports",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_deployer_account_broker",
-          "agency": "General Services Administration",
-          "project_name": "deployer-account-broker",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_tock_task_timer_script",
-          "agency": "General Services Administration",
-          "project_name": "tock-task-timer-script",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_acquisitions_18f_gov",
-          "agency": "General Services Administration",
-          "project_name": "acquisitions.18f.gov",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_windows_stig_cookbook",
-          "agency": "General Services Administration",
-          "project_name": "windows_stig_cookbook",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_pdf_parser",
-          "agency": "General Services Administration",
-          "project_name": "pdf_parser",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_deploy_fugacious",
-          "agency": "General Services Administration",
-          "project_name": "cg-deploy-fugacious",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_stickyfill",
-          "agency": "General Services Administration",
-          "project_name": "stickyfill",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_research",
-          "agency": "General Services Administration",
-          "project_name": "research",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_node_continua11y_reports",
-          "agency": "General Services Administration",
-          "project_name": "node-continua11y-reports",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_node_continua11y_sitemapper",
-          "agency": "General Services Administration",
-          "project_name": "node-continua11y-sitemapper",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_s3_resource",
-          "agency": "General Services Administration",
-          "project_name": "s3-resource",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_18franklin",
-          "agency": "General Services Administration",
-          "project_name": "18franklin",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_zap_analyzer",
-          "agency": "General Services Administration",
-          "project_name": "zap-analyzer",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_reckoning",
-          "agency": "General Services Administration",
-          "project_name": "the-reckoning",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_accessibility_practice_site",
-          "agency": "General Services Administration",
-          "project_name": "accessibility-practice-site",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_far_cry",
-          "agency": "General Services Administration",
-          "project_name": "far-cry",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_identity_monitor",
-          "agency": "General Services Administration",
-          "project_name": "identity-monitor",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_ie11_stig_dsc",
-          "agency": "General Services Administration",
-          "project_name": "ie11_stig_dsc",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_micropurchase_auctions",
-          "agency": "General Services Administration",
-          "project_name": "micropurchase-auctions",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_e_qip_prototype",
-          "agency": "General Services Administration",
-          "project_name": "e-QIP-prototype",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_generator_uswds",
-          "agency": "General Services Administration",
-          "project_name": "generator-uswds",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cf_redirect",
-          "agency": "General Services Administration",
-          "project_name": "cf-redirect",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_calc_analysis",
-          "agency": "General Services Administration",
-          "project_name": "calc-analysis",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_skills_share",
-          "agency": "General Services Administration",
-          "project_name": "skills_share",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_ops_improvements",
-          "agency": "General Services Administration",
-          "project_name": "ops-improvements",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_paid_leave_prototype",
-          "agency": "General Services Administration",
-          "project_name": "Paid-Leave-Prototype",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_notifications",
-          "agency": "General Services Administration",
-          "project_name": "notifications",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cg_deploy_notifications",
-          "agency": "General Services Administration",
-          "project_name": "cg-deploy-notifications",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_identity_pii_management",
-          "agency": "General Services Administration",
-          "project_name": "identity-pii-management",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_postgres",
-          "agency": "General Services Administration",
-          "project_name": "postgres",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_uswds_jekyll",
-          "agency": "General Services Administration",
-          "project_name": "uswds-jekyll",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_git_seekret",
-          "agency": "General Services Administration",
-          "project_name": "git-seekret",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cloud_native_aws_terraform_workshop",
-          "agency": "General Services Administration",
-          "project_name": "cloud-native-aws-terraform-workshop",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_far_clauses_tool",
-          "agency": "General Services Administration",
-          "project_name": "far-clauses-tool",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_federal_apis",
-          "agency": "General Services Administration",
-          "project_name": "federal-apis",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_test_docsite",
-          "agency": "General Services Administration",
-          "project_name": "test-docsite",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_visual_design",
-          "agency": "General Services Administration",
-          "project_name": "visual-design",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_cf_route_lookup",
-          "agency": "General Services Administration",
-          "project_name": "cf-route-lookup",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_identity_analysis_sandbox",
-          "agency": "General Services Administration",
-          "project_name": "identity-analysis-sandbox",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_crime_data_explorer",
-          "agency": "General Services Administration",
-          "project_name": "crime-data-explorer",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        },
-        {
-          "repoID": "gsa_crime_data_style",
-          "agency": "General Services Administration",
-          "project_name": "crime-data-style",
-          "issues": {
-            "enhancements": [],
-            "warnings": [],
-            "errors": [
-              {
-                "keyword": "required",
-                "dataPath": "",
-                "schemaPath": "#/required",
-                "params": {
-                  "missingProperty": "repository"
-                },
-                "message": "should have required property 'repository'"
-              }
-            ]
-          }
-        }
-      ],
+      "status": "FULLY COMPLIANT: 0 validation errors",
+      "issues": [],
+      "version": "1.0.1",
       "metadata": {
         "agency": {
           "name": "General Services Administration",
           "acronym": "GSA",
           "website": "https://gsa.gov/",
-          "codeUrl": "https://gsa.gov/code.json",
+          "codeUrl": "/data/fallback/GSA.json",
           "requirements": {
             "agencyWidePolicy": 1,
             "openSourceRequirement": 1,
-            "inventoryRequirement": 0.5,
-            "schemaFormat": 0.5,
-            "overallCompliance": 0.75
+            "inventoryRequirement": 1,
+            "schemaFormat": 1,
+            "overallCompliance": 1
           }
         }
       },
       "requirements": {
         "agencyWidePolicy": 1,
         "openSourceRequirement": 1,
-        "inventoryRequirement": 0.5,
-        "schemaFormat": 0.5,
-        "overallCompliance": 0.75
+        "inventoryRequirement": 1,
+        "schemaFormat": 1,
+        "overallCompliance": 1
       }
     },
     "NSF": {
@@ -17581,7 +8497,7 @@
           "name": "National Science Foundation",
           "acronym": "NSF",
           "website": "https://nsf.gov/",
-          "codeUrl": "https://nsf.gov/code.json",
+          "codeUrl": "/data/fallback/NSF.json",
           "requirements": {
             "agencyWidePolicy": 1,
             "openSourceRequirement": 1,
@@ -17600,34 +8516,34 @@
       }
     },
     "NRC": {
-      "status": "FAILURE: ERROR WHEN FETCHING (read ETIMEDOUT)",
+      "status": "FULLY COMPLIANT: 0 validation errors",
       "issues": [],
-      "version": "",
+      "version": "1.0.1",
       "metadata": {
         "agency": {
           "name": "Nuclear Regulatory Commission",
           "acronym": "NRC",
           "website": "https://www.nrc.gov/",
-          "codeUrl": "https://www.nrc.gov/code.json",
+          "codeUrl": "/data/fallback/NRC.json",
           "requirements": {
-            "agencyWidePolicy": 1,
-            "openSourceRequirement": 1,
+            "agencyWidePolicy": 0.5,
+            "openSourceRequirement": 0,
             "inventoryRequirement": 1,
-            "schemaFormat": 0,
-            "overallCompliance": 0.75
+            "schemaFormat": 1,
+            "overallCompliance": 0.5
           }
         }
       },
       "requirements": {
-        "agencyWidePolicy": 1,
-        "openSourceRequirement": 1,
+        "agencyWidePolicy": 0.5,
+        "openSourceRequirement": 0,
         "inventoryRequirement": 1,
-        "schemaFormat": 0,
-        "overallCompliance": 0.75
+        "schemaFormat": 1,
+        "overallCompliance": 0.5
       }
     },
     "OPM": {
-      "status": "FAILURE: ERROR WHEN FETCHING (Unexpected token < in JSON at position 0)",
+      "status": "FAILURE: MISSING PROJECTS FIELD",
       "issues": [],
       "version": "",
       "metadata": {
@@ -17636,13 +8552,13 @@
           "name": "Office of Personnel Management",
           "acronym": "OPM",
           "website": "https://opm.gov/",
-          "codeUrl": "https://opm.gov/code.json",
+          "codeUrl": "/data/fallback/OPM.json",
           "requirements": {
             "agencyWidePolicy": 0.5,
             "openSourceRequirement": 0,
             "inventoryRequirement": 0,
             "schemaFormat": 0,
-            "overallCompliance": 0.125
+            "overallCompliance": 0
           }
         }
       },
@@ -17651,24 +8567,55 @@
         "openSourceRequirement": 0,
         "inventoryRequirement": 0,
         "schemaFormat": 0,
-        "overallCompliance": 0.125
+        "overallCompliance": 0
       }
     },
     "SBA": {
-      "status": "FULLY COMPLIANT: 0 validation errors",
-      "issues": [],
+      "status": "NOT FULLY COMPLIANT: 1 ERRORS, 1 validation errors, 1 REQUESTED ENHANCEMENTS",
+      "issues": [
+        {
+          "repoID": "sba_oracletosql",
+          "agency": "Small Business Administration",
+          "project_name": "OracletoSQL",
+          "issues": {
+            "enhancements": [
+              {
+                "keyword": "format",
+                "dataPath": ".license",
+                "schemaPath": "#/properties/license/format",
+                "params": {
+                  "format": "uri"
+                },
+                "message": "should match format \"uri\""
+              }
+            ],
+            "warnings": [],
+            "errors": [
+              {
+                "keyword": "required",
+                "dataPath": "",
+                "schemaPath": "#/required",
+                "params": {
+                  "missingProperty": "tags"
+                },
+                "message": "should have required property 'tags'"
+              }
+            ]
+          }
+        }
+      ],
       "metadata": {
         "agency": {
           "name": "Small Business Administration",
           "acronym": "SBA",
           "website": "https://sba.gov/",
-          "codeUrl": "https://sba.gov/code.json",
+          "codeUrl": "/data/fallback/SBA.json",
           "requirements": {
             "agencyWidePolicy": 1,
             "openSourceRequirement": 0,
             "inventoryRequirement": 0,
-            "schemaFormat": 1,
-            "overallCompliance": 0.5
+            "schemaFormat": 0.5,
+            "overallCompliance": 0
           }
         }
       },
@@ -17676,8 +8623,8 @@
         "agencyWidePolicy": 1,
         "openSourceRequirement": 0,
         "inventoryRequirement": 0,
-        "schemaFormat": 1,
-        "overallCompliance": 0.5
+        "schemaFormat": 0.5,
+        "overallCompliance": 0
       }
     },
     "NARA": {
@@ -17689,40 +8636,13 @@
           "name": "National Archives",
           "acronym": "NARA",
           "website": "https://archives.gov/",
-          "codeUrl": "https://archives.gov/code.json",
-          "requirements": {
-            "agencyWidePolicy": 1,
-            "openSourceRequirement": 0.5,
-            "inventoryRequirement": 0.5,
-            "schemaFormat": 1,
-            "overallCompliance": 0.75
-          }
-        }
-      },
-      "requirements": {
-        "agencyWidePolicy": 1,
-        "openSourceRequirement": 0.5,
-        "inventoryRequirement": 0.5,
-        "schemaFormat": 1,
-        "overallCompliance": 0.75
-      }
-    },
-    "CFPB": {
-      "status": "FULLY COMPLIANT: 0 validation errors",
-      "issues": [],
-      "version": "1.0.1",
-      "metadata": {
-        "agency": {
-          "name": "Consumer Financial Protection Bureau",
-          "acronym": "CFPB",
-          "website": "https://consumerfinance.gov/",
-          "codeUrl": "https://consumerfinance.gov/code.json",
+          "codeUrl": "/data/fallback/NARA.json",
           "requirements": {
             "agencyWidePolicy": null,
             "openSourceRequirement": null,
             "inventoryRequirement": null,
             "schemaFormat": 1,
-            "overallCompliance": 0.25
+            "overallCompliance": 0
           }
         }
       },
@@ -17731,11 +8651,39 @@
         "openSourceRequirement": null,
         "inventoryRequirement": null,
         "schemaFormat": 1,
-        "overallCompliance": 0.25
+        "overallCompliance": 0
+      }
+    },
+    "CFPB": {
+      "status": "FAILURE: MISSING PROJECTS FIELD",
+      "issues": [],
+      "version": "",
+      "metadata": {
+        "agency": {
+          "id": 25,
+          "name": "Consumer Financial Protection Bureau",
+          "acronym": "CFPB",
+          "website": "https://consumerfinance.gov/",
+          "codeUrl": "/data/fallback/CFPB.json",
+          "requirements": {
+            "agencyWidePolicy": null,
+            "openSourceRequirement": null,
+            "inventoryRequirement": null,
+            "schemaFormat": 0,
+            "overallCompliance": 0
+          }
+        }
+      },
+      "requirements": {
+        "agencyWidePolicy": null,
+        "openSourceRequirement": null,
+        "inventoryRequirement": null,
+        "schemaFormat": 0,
+        "overallCompliance": 0
       }
     },
     "EOP": {
-      "status": "FAILURE: ERROR WHEN FETCHING (Unexpected token < in JSON at position 0)",
+      "status": "FAILURE: MISSING PROJECTS FIELD",
       "issues": [],
       "version": "",
       "metadata": {
@@ -17744,7 +8692,7 @@
           "name": "White House - Executive Office of the President",
           "acronym": "EOP",
           "website": "https://whitehouse.gov/",
-          "codeUrl": "https://whitehouse.gov/code.json",
+          "codeUrl": "/data/fallback/EOP.json",
           "requirements": {
             "agencyWidePolicy": null,
             "openSourceRequirement": null,
@@ -17771,13 +8719,13 @@
           "name": "Social Security Administration",
           "acronym": "SSA",
           "website": "https://www.ssa.gov",
-          "codeUrl": "https://www.ssa.gov/code.json",
+          "codeUrl": "data/fallback/SSA.json",
           "requirements": {
             "agencyWidePolicy": 1,
             "openSourceRequirement": 1,
             "inventoryRequirement": 0.5,
             "schemaFormat": 1,
-            "overallCompliance": 0.875
+            "overallCompliance": 0.8333333333333334
           }
         }
       },
@@ -17786,7 +8734,7 @@
         "openSourceRequirement": 1,
         "inventoryRequirement": 0.5,
         "schemaFormat": 1,
-        "overallCompliance": 0.875
+        "overallCompliance": 0.8333333333333334
       }
     }
   }

--- a/services/indexer/repo/index.js
+++ b/services/indexer/repo/index.js
@@ -327,14 +327,24 @@ class AgencyJsonStream extends Transform {
   }
 
   _calculateOverallCompliance(requirements){
-    //overallCompliance should be the average of the other requirements.
-    //TODO: align this approach with project-open-data's approach
-    let overallCompliance = 0;
-    for (let req in requirements){
-      overallCompliance += requirements[req];
+    // overallCompliance should be:
+    //  - 0 if 2 or more compliances are 0
+    //  - 1 if all 3 are 1
+    //  - otherwise the average of the requirements
+    //
+    // TODO: align this approach with project-open-data's approach
+    const compliances = [
+      requirements.agencyWidePolicy,
+      requirements.openSourceRequirement,
+      requirements.inventoryRequirement
+    ];
+    const counts = _.countBy(compliances, _.identity);
+
+    if (counts['0'] === 2) {
+      return 0;
+    } else {
+      return _.mean(compliances);
     }
-    overallCompliance /= _.size(requirements);
-    return overallCompliance;
   }
 
 }


### PR DESCRIPTION
### Why?

* As part of the new external compliance dashboard, we would like to show whether agencies are recording all their projects and whether they have contributed >20% of their projects to open source.

### What Changed?

* Added additional fields to the `agency_endpoints.json` to capture this data.
* Changed the calculation for overall compliance
  * Green if all 3 properties are green
  * Red if 2 or more properties are red
  * Yellow otherwise