### PR TITLE
Add CLOUD_GOV environment variable and set it to true

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -10,6 +10,7 @@ applications:
     ES_HEAP_SIZE: 10g
     CF_STAGING_TIMEOUT: 15
     CF_STARTUP_TIMEOUT: 15
+    CLOUD_GOV: true
   services:
   - code_gov_elasticsearch
   stack: cflinuxfs2


### PR DESCRIPTION
# Why

The config module is now checking if the app is running on Cloud.gov. This will let the app configure the Elasticsearch config vars it needs to connect to the service

# What changed

Added CLOUD_GOV environment variable to the manifest.yml. - ef34f70