### PR TITLE
Change indexer to 2.0

### DIFF
--- a/indexes/repo/mapping_200.json
+++ b/indexes/repo/mapping_200.json
@@ -6,12 +6,60 @@
                 "index": "not_analyzed"
             },
             "agency": {
-                "type": "string",
-                "analyzer": "keyword_ci",
-                "fields": {
-                    "_fulltext": {
+                "type": "nested",
+                "properties": {
+                    "name": {
                         "type": "string",
-                        "analyzer": "englishfulltext"
+                        "analyzer": "keyword_ci",
+                        "fields": {
+                            "_fulltext": {
+                                "type": "string",
+                                "analyzer": "englishfulltext"
+                            }
+                        }
+                    },
+                    "acronym": {
+                        "type": "string",
+                        "analyzer": "keyword_ci",
+                        "fields": {
+                            "_fulltext": {
+                                "type": "string",
+                                "analyzer": "keyword_ci"
+                            }
+                        }
+                    },
+                    "website": {
+                        "type": "string",
+                        "index": "not_analyzed"
+                    },
+                    "codeUrl": {
+                        "type": "string",
+                        "index": "not_analyzed"
+                    },
+                    "requirements": {
+                        "type": "nested",
+                        "properties": {
+                            "agencyWidePolicy": {
+                                "type": "float",
+                                "index": "not_analyzed"
+                            }, 
+                            "openSourceRequirement": {
+                                "type": "float",
+                                "index": "not_analyzed"
+                            },
+                            "inventoryRequirement": {
+                                "type": "float",
+                                "index": "not_analyzed"
+                            },
+                            "schemaFormat": {
+                                "type": "float",
+                                "index": "not_analyzed"
+                            },
+                            "overallCompliance": {
+                                "type": "float",
+                                "index": "not_analyzed"
+                            }
+                        }
                     }
                 }
             },
@@ -53,6 +101,14 @@
                 "analyzer": "keyword_ci"
             },
             "name": {
+                "type": "string",
+                "analyzer": "keyword_ci"
+            },
+            "version": {
+                "type": "string",
+                "analyzer": "keyword_ci"
+            },
+            "organization": {
                 "type": "string",
                 "analyzer": "keyword_ci"
             },
@@ -275,21 +331,21 @@
                     }
                 }
             },
-            "updated": {
+            "date": {
                 "type": "nested",
                 "include_in_root": true,
                 "properties": {
                     "metadataLastUpdated": {
                         "type": "date",
-                        "format": "strict_date_optional_time||epoch_millis"
+                        "ignore_malformed": true
                     },
                     "lastCommit": {
                         "type": "date",
-                        "format": "strict_date_optional_time||epoch_millis"
+                        "ignore_malformed": true
                     },
                     "sourceCodeLastModified": {
                         "type": "date",
-                        "format": "strict_date_optional_time||epoch_millis"
+                        "ignore_malformed": true
                     }
                 }
             }

--- a/services/formatter/index.js
+++ b/services/formatter/index.js
@@ -565,23 +565,26 @@ class Formatter {
   }
 
   formatRepo(schemaVersion = '1.0.1', repo, callback) {
-    let formattedRepo;
-    try {
-      if(schemaVersion === '2.0.0') {
-        formattedRepo = this._formatRepo(repo);
-      } else {
-        this._upgradeProject(repo);
-        formattedRepo = this._formatRepo(repo);
+    return new Promise((resolve, reject) => {
+      let formattedRepo;
+      try {
+        if(schemaVersion === '2.0.0') {
+          formattedRepo = this._formatRepo(repo);
+        } else {
+          this._upgradeProject(repo);
+          formattedRepo = this._formatRepo(repo);
+        }
+        
+        this.logger.debug('formatted repo', formattedRepo);
+      } catch (error) {
+        this.logger.error(`Error when formatting repo: ${error}`);
+        reject(error);
       }
-      
-      this.logger.debug('formatted repo', formattedRepo);
-    } catch (error) {
-      this.logger.error(`Error when formatting repo: ${error}`);
-      return callback(error, repo);
-    }
-
-    this.logger.debug(`Formatted repo ${repo.name} (${repo.repoID}).`);
-    return callback(null, repo);
+  
+      this.logger.debug(`Formatted repo ${repo.name} (${repo.repoID}).`);
+      resolve(repo);
+    });
+    
   }
 }
 

--- a/services/formatter/index.js
+++ b/services/formatter/index.js
@@ -475,18 +475,18 @@ class Formatter {
 
   }
   _upgradeOptionalFields(repo) {
-    repo.vcs = repo.vcs || ''
-    repo.disclaimerText = repo.disclaimerText || ''
-    repo.disclaimerURL = repo.disclaimerURL || ''
+    repo.vcs = repo.vcs || '';
+    repo.disclaimerText = repo.disclaimerText || '';
+    repo.disclaimerURL = repo.disclaimerURL || '';
     repo.relatedCode = [{
       codeName: '',
       codeURL: '',
-      isGovernmentRepo: false,
-    }]
+      isGovernmentRepo: false
+    }];
     repo.reusedCode = [{
       name: '',
-      URL: '',
-    }]
+      URL: ''
+    }];
   }
   _upgradeToPermissions(repo) {
 
@@ -564,7 +564,7 @@ class Formatter {
     return repo;
   }
 
-  formatRepo(schemaVersion = '1.0.1', repo, callback) {
+  formatRepo(schemaVersion = '1.0.1', repo) {
     return new Promise((resolve, reject) => {
       let formattedRepo;
       try {

--- a/services/formatter/index.js
+++ b/services/formatter/index.js
@@ -490,16 +490,15 @@ class Formatter {
   }
   _upgradeToPermissions(repo) {
 
-    repo.permissions = {};
-    repo.permissions.licenses = [];
-
-    repo.permissions.licenses.push({
-      URL: repo.license ? repo.license: null,
-      name: null
-    });
     const { usageType, exemptionText } = this._getUsageTypeExemptionText(repo);
-
-    repo.permissions= { usageType, exemptionText };
+    repo.permissions = { 
+      usageType, 
+      exemptionText,
+      licenses: [{
+        URL: repo.license ? repo.license: '',
+        name: ''
+      }]
+    };
 
     delete repo.license;
     delete repo.openSourceProject;
@@ -508,35 +507,36 @@ class Formatter {
     delete repo.exemptionText;
   }
   _upgradeUpdatedToDate(repo) {
-    repo.date = {
-      created: '',
-      lastModified: '',
-      metadataLastUpdated: '',
-    };
-  
+    let lastModified = '', 
+      metadataLastUpdated = '';
+
     if (repo.updated) {
       if (repo.updated.sourceCodeLastModified) {
-        repo.date.lastModified = this._formatDate(repo.updated.sourceCodeLastModified);
+        lastModified = this._formatDate(repo.updated.sourceCodeLastModified);
       }
   
       if (repo.updated.metadataLastUpdated) {
-        repo.date.metadataLastUpdated = this._formatDate(repo.updated.metadataLastUpdated);
+        metadataLastUpdated = this._formatDate(repo.updated.metadataLastUpdated);
       }
   
       delete repo.updated;
     }
+
+    repo.date = {
+      created: '',
+      lastModified: lastModified,
+      metadataLastUpdated: metadataLastUpdated
+    };
   }
   _upgradeProject(repo) {
-    repo.repositoryURL = repo.repository;
+    repo.laborHours = null;
+    repo.repositoryURL = repo.repository ? repo.repository : '';
+    repo.homepageURL = repo.homepage ? repo.homepage : '';
+
     delete repo.repository;
-  
-    repo.homepageURL = repo.homepage;
     delete repo.homepage;
   
-    this._upgradeToPermissions(repo);
-  
-    repo.laborHours = null;
-  
+    this._upgradeToPermissions(repo);  
     this._upgradeUpdatedToDate(repo);
     this._upgradeOptionalFields(repo);
   

--- a/services/formatter/repo_upgrade_texts.json
+++ b/services/formatter/repo_upgrade_texts.json
@@ -1,0 +1,9 @@
+{
+    "openSource": null,
+    "governmentWideReuse": null,
+    "exemptByLaw": "The sharing of the source code is restricted by law or regulation, including—but not limited to—patent or intellectual property law, the Export Asset Regulations, the International Traffic in Arms Regulation, and the Federal laws and regulations governing classified information.",
+    "exemptByNationalSecurity": "The sharing of the source code would create an identifiable risk to the detriment of national security, confidentiality of Government information, or individual privacy.",
+    "exemptByAgencySystem": "The sharing of the source code would create an identifiable risk to the stability, security, or integrity of the agency’s systems or personnel.",
+    "exemptByAgencyMission": "The sharing of the source code would create an identifiable risk to agency mission, programs, or operations.",
+    "exemptByCIO": "The CIO believes it is in the national interest to exempt sharing the source code."
+}

--- a/services/indexer/repo/index.js
+++ b/services/indexer/repo/index.js
@@ -6,7 +6,7 @@ const AbstractIndexer = require("../abstract_indexer");
 
 const AgencyJsonStream = require("../repo/AgencyJsonStream");
 const RepoIndexerStream = require("../repo/RepoIndexStream");
-const ES_MAPPING = require("../../../indexes/repo/mapping_100.json");
+const ES_MAPPING = require("../../../indexes/repo/mapping_200.json");
 
 const ES_SETTINGS = require("../../../indexes/repo/settings.json");
 const ES_PARAMS = {

--- a/services/indexer/term/index.js
+++ b/services/indexer/term/index.js
@@ -61,7 +61,7 @@ class RepoTermIndexerStream extends Writable {
   _write(term, enc, next) {
     this._indexTerm(term)
       .then(response => {
-        return next(null, response)
+        return next(null, response);
       })
       .catch(error => {
         return next(error, null);
@@ -103,7 +103,7 @@ class TermIndexer extends AbstractIndexer {
     indexer.indexExists()
       .then((exists) => {
         if(exists) {
-          indexer.deleteIndex()
+          indexer.deleteIndex();
         }
       })
       .then(() => indexer.initIndex())

--- a/test/services/indexer/repo/agencyJsonStream.test.js
+++ b/test/services/indexer/repo/agencyJsonStream.test.js
@@ -23,52 +23,52 @@ describe('AgencyJsonStream', function() {
     agencyJsonStream = new AgencyJsonStream(fetchDataDir, fallbackDataDir);
   });
 
-  it('Should save codeJson to disk', function(done) {
+  it('Should save codeJson to disk', function() {
     const codeJson = JsonFile.readFileSync(path.join(fallbackDataDir, '/FAKE.json'));
 
-    agencyJsonStream._saveFetchedCodeJson('FAKE', codeJson)
+    return agencyJsonStream._saveFetchedCodeJson('FAKE', codeJson)
       .then(data =>{
         const fetchedCodeJson = JsonFile.readFileSync(path.join(fetchDataDir, '/FAKE.json'));
         data.should.be.deep.equal(fetchedCodeJson);
-      })
-      .then(done, done);
+      });
   });
 
-  it('Should return codejson from disk', function(done) {
+  it('Should return codejson from disk', function() {
     const codeJson = JsonFile.readFileSync(path.join(fallbackDataDir, '/FAKE.json'));
-    agencyJsonStream._getAgencyCodeJson(agency[0])
+    return agencyJsonStream._getAgencyCodeJson(agency[0])
       .then(data => {
         data.should.be.deep.equal(codeJson);
-      })
-      .then(done, done);
+      });
   });
 
-  it('Should return array of repos', function(done){
+  it('Should return array of repos', function(){
     const codeJson = JsonFile.readFileSync(path.join(fallbackDataDir, '/FAKE.json'));
     const expectedRepos = codeJson.projects;
-    agencyJsonStream._validateAgencyRepos(agency[0], codeJson)
-      .then(repos => {
-        repos.should.be.deep.equal(expectedRepos);
-      })
-      .then(done, done);
+    return agencyJsonStream._validateAgencyRepos(agency[0], codeJson)
+      .then(result => {
+        result.repos.should.be.deep.equal(expectedRepos);
+      });
   });
 
-  it('Should return fomatted repos', function(done){
+  it.only('Should return fomatted repos', function(done){
     const expectedRepo = {
       name: 'Save Mail',
       organization: 'FAKE_ORG',
       description: 'FAKE Gmail extension to save messages to local disk',
-      license: null,
-      openSourceProject: 0,
-      governmentWideReuseProject: 0,
+      permissions: {
+        licenses: [{
+          URL: '',
+          name: ''
+        }],
+        usageType: 'openSource',
+        exemptionText: null
+      },
       tags: ['save', 'mail'],
       contact: { email: 'fake@fake.gov', name: 'Derp Fakerson', phone: '5555555555' },
       status: 'Production',
       vcs: 'git',
-      homepage: 'https://github.com/FAKEGOV/FAKEMailSaveMessageExtension-',
+      homepageURL: 'https://github.com/FAKEGOV/FAKEMailSaveMessageExtension-',
       downloadURL: 'https://github.com/FAKE_ORG/FAKEMailSaveMessageExtension-/archive/master.zip',
-      exemption: null,
-      exemptionText: 'No exemption requested',
       updated: { lastCommit: '2017-04-11T00:00:00.000Z', metadataLastUpdated: '2017-04-22T00:00:00.000Z', lastModified: '2017-04-11' },
       agency: {
         name: 'Department of FAKE',
@@ -84,13 +84,9 @@ describe('AgencyJsonStream', function() {
     const jsonStream = JsonStream.parse('*');
 
     agencyStream.pipe(jsonStream).pipe(agencyJsonStream).on('data', (repos) => {
-      try {
-        repos.should.be.deep.equal(expectedRepo);
-        done();
-      }catch(err) {
-        done(err);
-      }
-    });
+      repos.should.be.deep.equal(expectedRepo);
+      done();
+    }).on('error', (error) => done(error));
   });
 
   describe('Compliance Calculations', function() {

--- a/test/services/indexer/repo/agencyJsonStream.test.js
+++ b/test/services/indexer/repo/agencyJsonStream.test.js
@@ -51,7 +51,7 @@ describe('AgencyJsonStream', function() {
   });
 
   it('Should return fomatted repos', function(){
-    const expectedFormattedRepo = {
+    const expectedFormattedRepo = [{
       name: 'Save Mail',
       organization: 'FAKE_ORG',
       description: 'FAKE Gmail extension to save messages to local disk',
@@ -95,7 +95,7 @@ describe('AgencyJsonStream', function() {
         metadataLastUpdated: '2017-04-22T00:00:00.000Z'
       },
       repoID: 'fake_fake_org_save_mail' 
-    }
+    }]
     const codeJson = JsonFile.readFileSync(path.join(fallbackDataDir, '/FAKE.json'));
 
     return agencyJsonStream._formatRepos(agency[0], { schemaVersion: '1.0.1', repos: codeJson.projects })

--- a/test/services/indexer/repo/agencyJsonStream.test.js
+++ b/test/services/indexer/repo/agencyJsonStream.test.js
@@ -50,8 +50,8 @@ describe('AgencyJsonStream', function() {
       });
   });
 
-  it.only('Should return fomatted repos', function(done){
-    const expectedRepo = {
+  it('Should return fomatted repos', function(){
+    const expectedFormattedRepo = {
       name: 'Save Mail',
       organization: 'FAKE_ORG',
       description: 'FAKE Gmail extension to save messages to local disk',
@@ -67,9 +67,9 @@ describe('AgencyJsonStream', function() {
       contact: { email: 'fake@fake.gov', name: 'Derp Fakerson', phone: '5555555555' },
       status: 'Production',
       vcs: 'git',
+      laborHours: null,
       homepageURL: 'https://github.com/FAKEGOV/FAKEMailSaveMessageExtension-',
       downloadURL: 'https://github.com/FAKE_ORG/FAKEMailSaveMessageExtension-/archive/master.zip',
-      updated: { lastCommit: '2017-04-11T00:00:00.000Z', metadataLastUpdated: '2017-04-22T00:00:00.000Z', lastModified: '2017-04-11' },
       agency: {
         name: 'Department of FAKE',
         acronym: 'FAKE',
@@ -77,16 +77,30 @@ describe('AgencyJsonStream', function() {
         codeUrl: '/FAKE.json',
         requirements: { agencyWidePolicy: 0, openSourceRequirement: 0, inventoryRequirement: 0, schemaFormat: 1, overallCompliance: 0 }
       },
+      repositoryURL: '',
+      disclaimerText: '',
+      disclaimerURL: '',
+      relatedCode: [{
+        codeName: '',
+        codeURL: '',
+        isGovernmentRepo: false
+      }],
+      reusedCode: [{
+        URL: '',
+        name: ''
+      }],
+      date: {
+        created: '',
+        lastModified: '2017-04-11T00:00:00.000Z',
+        metadataLastUpdated: '2017-04-22T00:00:00.000Z'
+      },
       repoID: 'fake_fake_org_save_mail' 
     }
     const codeJson = JsonFile.readFileSync(path.join(fallbackDataDir, '/FAKE.json'));
-    const agencyStream = fs.createReadStream(path.join(testDataDir, 'test_agency_endpoints.json'));
-    const jsonStream = JsonStream.parse('*');
 
-    agencyStream.pipe(jsonStream).pipe(agencyJsonStream).on('data', (repos) => {
-      repos.should.be.deep.equal(expectedRepo);
-      done();
-    }).on('error', (error) => done(error));
+    return agencyJsonStream._formatRepos(agency[0], { schemaVersion: '1.0.1', repos: codeJson.projects })
+      .then(repo => repo.should.be.deep.equal(expectedFormattedRepo));
+
   });
 
   describe('Compliance Calculations', function() {

--- a/test/services/indexer/repo/test_data/fallback/FAKE.json
+++ b/test/services/indexer/repo/test_data/fallback/FAKE.json
@@ -7,7 +7,7 @@
         "organization": "FAKE_ORG",
         "description": "FAKE Gmail extension to save messages to local disk",
         "license": null,
-        "openSourceProject": 0,
+        "openSourceProject": 1,
         "governmentWideReuseProject": 0,
         "tags": [
           "save",
@@ -18,6 +18,7 @@
           "name": "Derp Fakerson",
           "phone": "5555555555"
         },
+        "repository": null,
         "status": "Production",
         "vcs": "git",
         "homepage": "https://github.com/FAKEGOV/FAKEMailSaveMessageExtension-",
@@ -27,7 +28,7 @@
         "updated": {
           "lastCommit": "2017-04-11",
           "metadataLastUpdated": "2017-04-22",
-          "lastModified": "2017-04-11"
+          "sourceCodeLastModified": "2017-04-11"
         }
       }
     ]

--- a/test/services/indexer/repo/test_data/test_agency_endpoints.json
+++ b/test/services/indexer/repo/test_data/test_agency_endpoints.json
@@ -5,8 +5,10 @@
   "website": "https://fake.gov/",
   "codeUrl": "/FAKE.json",
   "requirements": {
-    "agencyWidePolicy": 0,
-    "openSourceRequirement":0,
-    "inventoryRequirement":0
+    "agencyWidePolicy": 0, 
+    "openSourceRequirement": 0, 
+    "inventoryRequirement": 0, 
+    "schemaFormat": 1, 
+    "overallCompliance": 0 
   }
 }]

--- a/utils/index.js
+++ b/utils/index.js
@@ -121,9 +121,8 @@ class Utils {
 
   /**
    * Extract schema version from code.json
-   * @param {*} codeJson 
+   * @param {object} codeJson 
    */
-  
   static getCodeJsonVersion(codeJson) {
     if(codeJson.version) {
       return codeJson.version;
@@ -135,6 +134,22 @@ class Utils {
       } else {
         return '1.0.0';
       }
+    }
+  }
+
+  /**
+   * Extract repositories from code.json by checking the schema version
+   * @param {object} codeJson 
+   * @returns {array} Array with repositories / projects found in the code.json
+   */
+  static getCodeJsonRepos(codeJson) {
+    const version = this.getCodeJsonVersion(codeJson);
+    const version2RegExp = /^2(\.\d+){0,2}$/;
+
+    if(version2RegExp.test(version)) {
+      return codeJson.releases ? codeJson.releases : null;
+    } else {
+      return codeJson.projects ? codeJson.projects : null;
     }
   }
 }


### PR DESCRIPTION
# Why

Schema 2.0 support has to be ready by the end of the year deadline.

# What changed

Elasticsearch mappings where updated to conform to schema 2.0
Repo formatter service was updated to upgrade old repo formats to 2.0 elasticsearch mappings.

## Commits

- Update to most recent schema version 2.0 - 972e0d6
- Update elasticsearch mappings - 33a02f2
- Add helper function and fix JSDoc - 2142140
- Clean up promise code and change formatRepos call - e2c62b5
- Add upgrade repo to 2.0 helper functions. - e45fab7
- Added json file with exemption texts to clean up code in formater - 0a8199d
- Clean up tests with promises and updated repo expected format. - 4ea57db

Closes #110 #111  #112 