### PR TITLE
Change circleci hold job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,24 +120,29 @@ workflows:
       - test:
           requires:
             - build
-      - hold:
+      - deploy-staging-hold:
           type: approval
           requires:
             - test
           filters:
             branches:
               only: ${STAGING_DEPLOY_BRANCH}
+      - deploy-prod-hold:
+          type: approval
+          requires:
+            - test
+          filters:
             tags:
               only: ${DEPLOY_TAG_PATTERN}
       - deploy-staging:
           requires:
-            - hold
+            - deploy-staging-hold
           filters:
             branches: 
               only: ${STAGING_DEPLOY_BRANCH}
       - deploy-production:
           requires:
-            - hold
+            - deploy-prod-hold
           filters:
             tags:
               only: ${DEPLOY_TAG_PATTERN}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,8 @@ workflows:
           filters:
             branches:
               only: ${STAGING_DEPLOY_BRANCH}
+            tags:
+              ignore: /.*/
       - deploy-prod-hold:
           type: approval
           requires:
@@ -134,15 +136,21 @@ workflows:
           filters:
             tags:
               only: ${DEPLOY_TAG_PATTERN}
+            branches:
+              ignore: /.*/
       - deploy-staging:
           requires:
             - deploy-staging-hold
           filters:
             branches: 
               only: ${STAGING_DEPLOY_BRANCH}
+            tags:
+              ignore: /.*/
       - deploy-production:
           requires:
             - deploy-prod-hold
           filters:
             tags:
               only: ${DEPLOY_TAG_PATTERN}
+            branches:
+              ignore: /.*/


### PR DESCRIPTION
**Summary**

This PR fixes deployment hold jobs in our CircleCI config.

This PR fixes/implements the following **bugs/features**

* [x] Hold job was divided into deploy-staging-hold and deploy-prod-hold
* [x] deploy-staging-hold only runs on `master` branch
* [x] deploy-prod-hold only runs on our deployment tags
* [x] deploy-production job now requires deploy-prod-hold
* [x] deploy-staging now requires deploy-staging-hold

Explain the **motivation** for making this change. What existing problem does the pull request solve?

Wanted better controls on what jobs were being run on each push/PR.

**Test plan (required)**

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Successful workflow execution from CircleCI:
![image](https://user-images.githubusercontent.com/1918027/34583699-beb6fee0-f166-11e7-9028-bc56055db7f4.png)


**Code formatting**

**Closing issues**

  