### PR TITLE
Fix term indexing bug

### DIFF
--- a/services/indexer/term/index.js
+++ b/services/indexer/term/index.js
@@ -1,11 +1,11 @@
-const Writable            = require("stream");
+const Writable            = require("stream").Writable;
 const SearchStream        = require("../../../utils/search_stream");
 const AbstractIndexer     = require("../abstract_indexer");
 const RepoTermLoaderStream= require("./repo_term_loader_stream");
 
 // NOTE: dependent on elasticsearch repos being indexed
 
-const ES_REPO_MAPPING = require("../../../indexes/repo/mapping_100.json");
+const ES_REPO_MAPPING = require("../../../indexes/repo/mapping_200.json");
 const ES_REPO_SETTINGS = require("../../../indexes/repo/settings.json");
 const ES_REPO_PARAMS = {
   "esAlias": "repos",
@@ -42,19 +42,19 @@ class RepoTermIndexerStream extends Writable {
         "id": id,
         "body": term
       })
-      .then((response, status) => {
-        if (status) {
-          this.logger.debug('termIndexer.indexDocument - Status', status);
-        }
+        .then((response, status) => {
+          if (status) {
+            this.logger.debug('termIndexer.indexDocument - Status', status);
+          }
         
-        this.termIndexer.indexCounter++;
+          this.termIndexer.indexCounter++;
   
-        resolve(response);
-      })
-      .catch(err => {
-        this.logger.error(err);
-        reject(err);
-      });
+          resolve(response);
+        })
+        .catch(err => {
+          this.logger.error(err);
+          reject(err);
+        });
     });
   }
 

--- a/test/services/indexer/repo/agencyJsonStream.test.js
+++ b/test/services/indexer/repo/agencyJsonStream.test.js
@@ -5,6 +5,7 @@ const chai = require('chai');
 const JsonStream = require('JSONStream');
 const JsonFile = require('jsonfile');
 const should = chai.should();
+const moment = require('moment');
 
 const AgencyJsonStream = require('../../../../services/indexer/repo/AgencyJsonStream');
 
@@ -91,8 +92,8 @@ describe('AgencyJsonStream', function() {
       }],
       date: {
         created: '',
-        lastModified: '2017-04-11T00:00:00.000Z',
-        metadataLastUpdated: '2017-04-22T00:00:00.000Z'
+        lastModified: moment('2017-04-11', 'YYYY-MM-DD').utc().toJSON(),
+        metadataLastUpdated: moment('2017-04-22', 'YYYY-MM-DD').utc().toJSON()
       },
       repoID: 'fake_fake_org_save_mail' 
     }]


### PR DESCRIPTION
**Summary**

The `Writable` stream was not being imported correctly in `services/indexer/term/index.js` and causing the stream piping to not work correctly. The `RepoTermIndexerStream` would be set to Node's `stream` instead of `Writable`. This would cause the process to error out when trying to write to the stream object.

Once the `require` statement was corrected the indexing process worked as expected.

This PR fixes/implements the following **bugs/features**

* [x] Bug #160 

Explain the **motivation** for making this change. What existing problem does the pull request solve?

Terms were not being indexed correctly and thus the Code.gov indexing was incomplete.

**Test plan (required)**

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos if the pull request changes UI.

All current tests are passing.

![image](https://user-images.githubusercontent.com/1918027/35309972-f9c82372-0063-11e8-9ad3-0c240ba91d78.png)

**Closing issues**

Fixes #160 
