### PR TITLE
Add route to cf push for production and staging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
           name: deploy-to-staging
           command: |
             cf login -a ${CF_URL} -u ${CF_STAGING_DEPLOYER} -p ${CF_STAGING_DEPLOYER_PASS} -o ${CF_ORG} -s ${CF_STAGING_SPACE}
-            cf push ${CF_APP}
+            cf push ${CF_APP} -n code-api-staging.app.cloud.gov
   deploy-production:
     working_directory: ~/code-gov-api
     docker:
@@ -111,7 +111,7 @@ jobs:
       - deploy:
           command: |
               cf login -a ${CF_URL} -u ${CF_PRODUCTION_DEPLOYER} -p ${CF_PRODUCTION_DEPLOYER_PASS} -o ${CF_ORG} -s ${CF_PRODUCTION_SPACE}
-              cf push ${CF_APP}
+              cf push ${CF_APP} -n code-api.app.cloud.gov
 workflows:
   version: 2
   build-test-deploy:


### PR DESCRIPTION
**Summary**

Deployments were conflicting with the routes that were bound to them. The solution is to pass the route we want to be bound to the environment at the moment we are pushing.

This PR fixes/implements the following **bugs/features**

* [x] #182

Explain the **motivation** for making this change. What existing problem does the pull request solve?

We need the continuous deployment aspect of CircleCI to work correctly.

**Test plan (required)**

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

<!-- Make sure tests pass on both Travis and Circle CI. -->
<img width="442" alt="image" src="https://user-images.githubusercontent.com/1918027/35941595-cb2f84c4-0c20-11e8-8486-e05a6c683adb.png">

**Closing issues**

Closes #182