### PR TITLE
Fix view render bug

### DIFF
--- a/routes/routes.js
+++ b/routes/routes.js
@@ -96,7 +96,7 @@ function getApiRoutes(config, searcher, router) {
     getAgencyIssues(agency, config)
       .then(issuesData => {
         if (issuesData.statusData) {
-          return response.render(`status/${agency}/issues`, issuesData);
+          return response.render(`status/agency/issues`, issuesData);
         } else {
           return response.sendStatus(404);
         }


### PR DESCRIPTION
**Summary**

Fixes agency status details rendering bug.

**Motivation**

The app was returning an internal server error while looking for the issue details for an agency. This is due to the view path being wrong.

**Test plan (required)**

All test passing.

![image](https://user-images.githubusercontent.com/1918027/37043647-2c1369fe-212f-11e8-9066-a903febedb82.png)