### PR TITLE
DOD has requested to change code.json url, from defense.gov to code.mil

### DIFF
--- a/config/agency_metadata.json
+++ b/config/agency_metadata.json
@@ -35,7 +35,7 @@
     "name": "Department of Defense",
     "acronym": "DOD",
     "website": "https://www.defense.gov/",
-    "codeUrl": "https://www.defense.gov/code.json",
+    "codeUrl": "https://www.code.mil/code.json",
     "fallback_file": "DOD.json",
     "requirements": {
       "agencyWidePolicy": 0,


### PR DESCRIPTION
DOD would for code.gov to harvest the data from code.mil not defense.gov server.

