### PR TITLE
Sort agencies

### DIFF
--- a/routes/utils.js
+++ b/routes/utils.js
@@ -90,6 +90,13 @@ function getAgencyData (searcher, config, logger, options) {
           numRepos: term.count
         });
       });
+      agencies.sort((a,b) => {
+        if (a.name < b.name)
+          return -1;
+        if (a.name > b.name)
+          return 1;
+        return 0;
+      })
       return agencies;
     });
 }

--- a/routes/utils.js
+++ b/routes/utils.js
@@ -20,7 +20,7 @@ function readStatusReportFile (config) {
   });
 }
 
-function readAgencyEndpointsFile (config) {
+function readAgencyMetadataFile (config) {
   return new Promise((resolve, reject) => {
     fs.readFile(config.AGENCY_ENDPOINTS_FILE, (err, data) => {
       if (err) {
@@ -52,7 +52,7 @@ function getAgencyTerms (searcher, options) {
 }
 
 function getAgencyData (searcher, config, logger, options) {
-  return readAgencyEndpointsFile(config).then(agenciesData => {
+  return readAgencyMetadataFile(config).then(agenciesData => {
     let agenciesDataHash = {agencyMetaData: {}};
     agenciesData.forEach((agencyData) => {
       agenciesDataHash.agencyMetaData[agencyData.acronym] = agencyData;
@@ -92,11 +92,11 @@ function getAgencyData (searcher, config, logger, options) {
       });
       agencies.sort((a,b) => {
         if (a.name < b.name)
-          return -1;
+          return options.sort === 'asc' ? -1 : 1;
         if (a.name > b.name)
-          return 1;
+          return options.sort === 'asc' ? 1 : -1;
         return 0;
-      })
+      });
       return agencies;
     });
 }
@@ -210,7 +210,7 @@ function getTerms(request, response, searcher) {
 }
 
 function getAgencies(request, searcher, config, logger) {
-  let options = _.pick(request.query, ["size", "from"]);
+  let options = _.pick(request.query, ["size", "from", "sort"]);
   options.agency = request.query.agency;
   return getAgencyData(searcher, config, logger, options)
     .then((agencies) => {

--- a/swagger.json
+++ b/swagger.json
@@ -334,6 +334,14 @@
               "description": "Specify an offset to return",
               "required": false,
               "type": "number"
+            },
+            {
+              "name": "sort",
+              "in": "query",
+              "description": "Specify an sort by agency name",
+              "required": false,
+              "type": "string",
+              "enum": ["asc", "desc"]
             }
           ],
           "responses": {


### PR DESCRIPTION
**Summary**

The API's agencies endpoint now accepts the `sort` query parameter and will now sort by agency name.

This PR fixes/implements the following **bugs/features**

* [x] #165 

Explain the **motivation** for making this change. What existing problem does the pull request solve?

Our agency endpoint had no way to sort agencies by name. Our front-end needed this functionality at the API level.

The agencies endpoint now accepts a `sort` query parameter with the values __asc__ for ascending and __desc__ for descending. The ascending sorting value is the default.

**Test plan (required)**

<img width="485" alt="image" src="https://user-images.githubusercontent.com/1918027/37752160-dd07027c-2d6c-11e8-9568-3ec237d43226.png">

**Closing issues**

Closes #165 
