### PR TITLE
Increase default max result size to over 9,000

### DIFF
--- a/services/searcher/index.js
+++ b/services/searcher/index.js
@@ -6,7 +6,7 @@ const Logger              = require("../../utils/logger");
 const repoMapping         = require("../../indexes/repo/mapping_200.json");
 
 const DATE_FORMAT = "YYYY-MM-DD";
-const REPO_RESULT_SIZE_MAX = 3000;
+const REPO_RESULT_SIZE_MAX = 10000;
 const REPO_RESULT_SIZE_DEFAULT = 10;
 const TERM_RESULT_SIZE_MAX = 100;
 const TERM_RESULT_SIZE_DEFAULT = 5;


### PR DESCRIPTION
**Summary**

There is no simple way to help users paginate our results. For now we will set the max return to 10, 000 to ensure that all our repos are returned in one request.

**Test plan (required)**

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

![image](https://user-images.githubusercontent.com/1918027/39147325-4d069b06-4707-11e8-87fc-16f09279c258.png)
