### PR TITLE
Implement zero downtime deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,10 +127,15 @@ jobs:
             sudo dpkg -i cf-cli_amd64.deb
             cf -v
       - run:
+          name: install-cf-autopilot
+          command: |
+            curl -s https://api.github.com/repos/contraband/autopilot/releases/latest | grep "browser_download_url.*linux" | cut -d : -f 2,3 | tr -d \" | wget -qi -
+            cf install-plugin autopilot-linux
+      - run:
           name: deploy-to-staging
           command: |
             cf login -a ${CF_URL} -u ${CF_STAGING_DEPLOYER} -p ${CF_STAGING_DEPLOYER_PASS} -o ${CF_ORG} -s ${CF_STAGING_SPACE}
-            cf push ${CF_APP} -n code-api-staging.app.cloud.gov
+            cf zero-downtime-push code-api -f manifest-staging.yml
   deploy-production:
     working_directory: ~/code-gov-api
     docker:
@@ -152,11 +157,15 @@ jobs:
             curl -v -L -o cf-cli_amd64.deb 'https://cli.run.pivotal.io/stable?release=debian64&source=github'
             sudo dpkg -i cf-cli_amd64.deb
             cf -v
-      # Production deployment.
+       - run:
+          name: install-cf-autopilot
+          command: |
+            curl -s https://api.github.com/repos/contraband/autopilot/releases/latest | grep "browser_download_url.*linux" | cut -d : -f 2,3 | tr -d \" | wget -qi -
+            cf install-plugin autopilot-linux
       - deploy:
           command: |
               cf login -a ${CF_URL} -u ${CF_PRODUCTION_DEPLOYER} -p ${CF_PRODUCTION_DEPLOYER_PASS} -o ${CF_ORG} -s ${CF_PRODUCTION_SPACE}
-              cf push ${CF_APP} -n code-api.app.cloud.gov
+              cf zero-downtime-push code-api -f manifest.yml
 workflows:
   version: 2
   build-test-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ jobs:
        - run:
           name: install-cf-autopilot
           command: |
-            curl -s https://api.github.com/repos/contraband/autopilot/releases/latest | grep "browser_download_url.*linux" | cut -d : -f 2,3 | tr -d \" | wget -qi -
+            curl -s https://api.github.com/repos/contraband/autopilot/releases/latest |  grep "browser_download_url.*linux" | cut -d ":" -f 2,3 | tr -d \" | wget -qi -
             cf install-plugin autopilot-linux
       - deploy:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ jobs:
             curl -v -L -o cf-cli_amd64.deb 'https://cli.run.pivotal.io/stable?release=debian64&source=github'
             sudo dpkg -i cf-cli_amd64.deb
             cf -v
-       - run:
+      - run:
           name: install-cf-autopilot
           command: |
             curl -s https://api.github.com/repos/contraband/autopilot/releases/latest |  grep "browser_download_url.*linux" | cut -d ":" -f 2,3 | tr -d \" | wget -qi -

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ jobs:
       - run:
           name: install-cf-autopilot
           command: |
-            curl -s https://api.github.com/repos/contraband/autopilot/releases/latest | grep "browser_download_url.*linux" | cut -d : -f 2,3 | tr -d \" | wget -qi -
+            curl -s https://api.github.com/repos/contraband/autopilot/releases/latest | grep "browser_download_url.*linux" | cut -d ":" -f 2,3 | tr -d \" | wget -qi -
             cf install-plugin autopilot-linux
       - run:
           name: deploy-to-staging

--- a/manifest-dev.yml
+++ b/manifest-dev.yml
@@ -1,12 +1,12 @@
 applications:
 - name: code-api
-  memory: 1024M
+  memory: 512M
   instances: 1
-  disk_quota: 1024M
+  disk_quota: 512M
   health-check-type: http
   health-check-http-endpoint: /api
   routes:
-    - route: code-api.app.cloud.gov
+    - route: code-api-dev.app.cloud.gov
   buildpack: https://github.com/cloudfoundry/nodejs-buildpack
   env:
     ES_HEAP_SIZE: 10g

--- a/manifest-staging.yml
+++ b/manifest-staging.yml
@@ -6,7 +6,7 @@ applications:
   health-check-type: http
   health-check-http-endpoint: /api
   routes:
-    - route: code-api.app.cloud.gov
+    - route: code-api-staging.app.cloud.gov
   buildpack: https://github.com/cloudfoundry/nodejs-buildpack
   env:
     ES_HEAP_SIZE: 10g


### PR DESCRIPTION
**Summary**

Implemented zero downtime deployment strategy using [autopilot](https://github.com/contraband/autopilot) cf plugin.

Explain the **motivation** for making this change. What existing problem does the pull request solve?

Our deployments to all of our environment had some downtime. This downtime could be extended by a faulty deployment. To avoid service interruptions a zero downtime deployment strategy has been implemented. 

We are using the Cloud Foundry plugin called [autopilot](https://github.com/contraband/autopilot), which is recommended in the [Cloud.gov docs](https://cloud.gov/docs/apps/production-ready/#zero-downtime-deploy).

**Test plan (required)**
