### PR TITLE
Update EOP code.json url

### DIFF
--- a/config/agency_metadata.json
+++ b/config/agency_metadata.json
@@ -435,7 +435,7 @@
     "name": "Executive Office of the President",
     "acronym": "EOP",
     "website": "https://www.whitehouse.gov/",
-    "codeUrl": "https://www.whitehouse.gov/code.json",
+    "codeUrl": "https://raw.githubusercontent.com/EOP-OMB/code_json/master/code.json",
     "fallback_file": "EOP.json",
     "requirements": {
       "agencyWidePolicy": null,

--- a/data/fallback/EOP.json
+++ b/data/fallback/EOP.json
@@ -173,6 +173,7 @@
           }
         ],
         "usageType": "openSource",
+        "repositoryURL": "https://github.com/EOP-OMB/OGE-450",
         "exemptionText": null
       },
       "laborHours": 0,

--- a/data/fetched/EOP.json
+++ b/data/fetched/EOP.json
@@ -173,6 +173,7 @@
           }
         ],
         "usageType": "openSource",
+        "repositoryURL": "https://github.com/EOP-OMB/OGE-450",
         "exemptionText": null
       },
       "laborHours": 0,


### PR DESCRIPTION
**Summary**

- EOP code.json is now on Github and thus the url has been updated.
- Added new fetched code.json and fallback code.json

**Motivation**

EOP's code.json URL was out of date. This made it unharvestable.

**Test plan (required)**

<img width="488" alt="image" src="https://user-images.githubusercontent.com/1918027/40136210-3f044a24-5915-11e8-9fe9-79c4d59c02af.png">
