### PR TITLE
Update DOJ's agency policy status to green

### DIFF
--- a/config/agency_metadata.json
+++ b/config/agency_metadata.json
@@ -150,7 +150,7 @@
     "codeUrl": "https://www.justice.gov/code.json",
     "fallback_file": "DOJ.json",
     "requirements": {
-      "agencyWidePolicy": 0.75,
+      "agencyWidePolicy": 1,
       "openSourceRequirement": 0,
       "inventoryRequirement": 0,
       "schemaFormat": 0.5,


### PR DESCRIPTION
DOJ has approve and published their Open Source Policy to comply with the M-16-21 FSCP. 

Action to update the DOJ's agency policy status to green. 