### PR TITLE
Add nih changes

### DIFF
--- a/indexes/repo/mapping_201.json
+++ b/indexes/repo/mapping_201.json
@@ -1,0 +1,500 @@
+{
+  "repo": {
+    "properties": {
+      "repoID": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
+      "agency": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "analyzer": "keyword_ci",
+            "fields": {
+              "_fulltext": {
+                "type": "string",
+                "analyzer": "englishfulltext"
+              }
+            }
+          },
+          "acronym": {
+            "type": "string",
+            "analyzer": "keyword_ci",
+            "fields": {
+              "_fulltext": {
+                "type": "string",
+                "analyzer": "keyword_ci"
+              }
+            }
+          },
+          "website": {
+            "type": "string",
+            "index": "not_analyzed"
+          },
+          "codeUrl": {
+            "type": "string",
+            "index": "not_analyzed"
+          },
+          "requirements": {
+            "type": "nested",
+            "properties": {
+              "agencyWidePolicy": {
+                "type": "float",
+                "index": "not_analyzed"
+              },
+              "openSourceRequirement": {
+                "type": "float",
+                "index": "not_analyzed"
+              },
+              "inventoryRequirement": {
+                "type": "float",
+                "index": "not_analyzed"
+              },
+              "schemaFormat": {
+                "type": "float",
+                "index": "not_analyzed"
+              },
+              "overallCompliance": {
+                "type": "float",
+                "index": "not_analyzed"
+              }
+            }
+          }
+        }
+      },
+      "measurementType": {
+        "type": "object",
+        "properties": {
+          "method": {
+            "type": "string",
+            "analyzer": "keyword_ci",
+            "fields": {
+              "_fulltext": {
+                "type": "string",
+                "analyzer": "englishfulltext"
+              }
+            }
+          },
+          "ifOther": {
+            "type": "string",
+            "analyzer": "englishfulltext",
+            "fields": {
+              "_fulltext": {
+                "type": "string",
+                "analyzer": "englishfulltext"
+              }
+            }
+          }
+        }
+      },
+      "status": {
+        "type": "string",
+        "analyzer": "keyword_ci"
+      },
+      "vcs": {
+        "type": "string",
+        "analyzer": "keyword_ci"
+      },
+      "repositoryURL": {
+        "type": "string",
+        "analyzer": "keyword_ci"
+      },
+      "targetOperatingSystems": {
+        "type": "string",
+        "analyzer": "keyword_ci"
+      },
+      "name": {
+        "type": "string",
+        "analyzer": "keyword_ci",
+        "fields": {
+          "_fulltext": {
+            "type": "string",
+            "analyzer": "englishfulltext"
+          }
+        }
+      },
+      "version": {
+        "type": "string",
+        "analyzer": "keyword_ci"
+      },
+      "organization": {
+        "type": "string",
+        "analyzer": "keyword_ci",
+        "fields": {
+          "_fulltext": {
+            "type": "string",
+            "analyzer": "englishfulltext"
+          }
+        }
+      },
+      "homepageURL": {
+        "type": "string",
+        "analyzer": "keyword_ci"
+      },
+      "downloadURL": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
+      "description": {
+        "type": "string",
+        "analyzer": "englishfulltext"
+      },
+      "events": {
+        "type": "string",
+        "analyzer": "keyword_ci",
+        "fields": {
+          "_fulltext": {
+            "type": "string",
+            "analyzer": "englishfulltext"
+          }
+        }
+      },
+      "tags": {
+        "type": "string",
+        "analyzer": "keyword_ci",
+        "fields": {
+          "_fulltext": {
+            "type": "string",
+            "analyzer": "englishfulltext"
+          }
+        }
+      },
+      "languages": {
+        "type": "string",
+        "analyzer": "keyword_ci",
+        "fields": {
+          "_fulltext": {
+            "type": "string",
+            "analyzer": "englishfulltext"
+          }
+        }
+      },
+      "contact": {
+        "type": "object",
+        "include_in_root": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "analyzer": "keyword_ci",
+            "fields": {
+              "_fulltext": {
+                "type": "string",
+                "analyzer": "englishfulltext"
+              }
+            }
+          },
+          "email": {
+            "type": "string",
+            "analyzer": "keyword_ci",
+            "fields": {
+              "_fulltext": {
+                "type": "string",
+                "analyzer": "englishfulltext"
+              }
+            }
+          },
+          "twitter": {
+            "type": "string",
+            "analyzer": "keyword_ci",
+            "fields": {
+              "_fulltext": {
+                "type": "string",
+                "analyzer": "englishfulltext"
+              }
+            }
+          },
+          "phone": {
+            "type": "string",
+            "analyzer": "keyword_ci",
+            "fields": {
+              "_fulltext": {
+                "type": "string",
+                "analyzer": "englishfulltext"
+              }
+            }
+          }
+        }
+      },
+      "partners": {
+        "type": "nested",
+        "include_in_root": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "analyzer": "keyword_ci",
+            "fields": {
+              "_fulltext": {
+                "type": "string",
+                "analyzer": "englishfulltext"
+              }
+            }
+          },
+          "email": {
+            "type": "string",
+            "analyzer": "keyword_ci",
+            "fields": {
+              "_fulltext": {
+                "type": "string",
+                "analyzer": "englishfulltext"
+              }
+            }
+          }
+        }
+      },
+      "permissions": {
+        "type": "object",
+        "properties": {
+          "licenses": {
+            "type": "nested",
+            "properties": {
+              "name": {
+                "type": "string",
+                "analyzer": "keyword_ci",
+                "fields": {
+                  "_fulltext": {
+                    "type": "string",
+                    "analyzer": "englishfulltext"
+                  }
+                }
+              },
+              "URL": {
+                "type": "string",
+                "index": "not_analyzed"
+              }
+            }
+          },
+          "usageType": {
+            "type": "string",
+            "analyzer": "keyword_ci",
+            "fields": {
+              "_fulltext": {
+                "type": "string",
+                "analyzer": "englishfulltext"
+              }
+            }
+          },
+          "exemptionText": {
+            "type": "string",
+            "analyzer": "englishfulltext"
+          }
+        }
+      },
+      "laborHours": {
+        "type": "integer",
+        "index": "not_analyzed"
+      },
+      "relatedCode": {
+        "type": "nested",
+        "properties": {
+          "name": {
+            "type": "string",
+            "analyzer": "keyword_ci",
+            "fields": {
+              "_fulltext": {
+                "type": "string",
+                "analyzer": "englishfulltext"
+              }
+            }
+          },
+          "URL": {
+            "type": "string",
+            "index": "not_analyzed"
+          }
+        }
+      },
+      "reusedCode": {
+        "type": "nested",
+        "properties": {
+          "name": {
+            "type": "string",
+            "analyzer": "keyword_ci",
+            "fields": {
+              "_fulltext": {
+                "type": "string",
+                "analyzer": "englishfulltext"
+              }
+            }
+          },
+          "URL": {
+            "type": "string",
+            "index": "not_analyzed"
+          }
+        }
+      },
+      "disclaimerURL": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
+      "disclaimerText": {
+        "type": "string",
+        "analyzer": "englishfulltext"
+      },
+      "additionalInformation": {
+        "type": "object",
+        "dynamic": true
+      },
+      "date": {
+        "type": "nested",
+        "include_in_root": true,
+        "properties": {
+          "created": {
+            "type": "date",
+            "ignore_malformed": true
+          },
+          "lastModified": {
+            "type": "date",
+            "ignore_malformed": true
+          },
+          "metadataLastUpdated": {
+            "type": "date",
+            "ignore_malformed": true
+          }
+        }
+      }
+    }
+  },
+  "status": {
+    "properties": {
+      "last_data_harvest": {
+        "type": "date"
+      },
+      "version": {
+        "type": "string",
+        "index": "not_analyzed"
+      },
+      "agency": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "analyzer": "keyword_ci",
+            "fields": {
+              "_fulltext": {
+                "type": "string",
+                "analyzer": "englishfulltext"
+              }
+            }
+          },
+          "acronym": {
+            "type": "string",
+            "analyzer": "keyword_ci",
+            "fields": {
+              "_fulltext": {
+                "type": "string",
+                "analyzer": "keyword_ci"
+              }
+            }
+          },
+          "website": {
+            "type": "string",
+            "index": "not_analyzed"
+          },
+          "codeUrl": {
+            "type": "string",
+            "index": "not_analyzed"
+          },
+          "requirements": {
+            "type": "object",
+            "properties": {
+              "agencyWidePolicy": {
+                "type": "float",
+                "index": "not_analyzed"
+              },
+              "openSourceRequirement": {
+                "type": "float",
+                "index": "not_analyzed"
+              },
+              "inventoryRequirement": {
+                "type": "float",
+                "index": "not_analyzed"
+              },
+              "schemaFormat": {
+                "type": "float",
+                "index": "not_analyzed"
+              },
+              "overallCompliance": {
+                "type": "float",
+                "index": "not_analyzed"
+              }
+            }
+          }
+        }
+      },
+      "issues": {
+        "type": "nested",
+        "properties": {
+          "organization": {
+            "type": "string"
+          },
+          "project_name": {
+            "type": "string"
+          },
+          "errors": {
+            "type": "nested",
+            "properties": {
+              "keyword": {
+                "type": "string"
+              },
+              "dataPath": {
+                "type": "string"
+              },
+              "schemaPath": {
+                "type": "string"
+              },
+              "params": {
+                "type": "object"
+              },
+              "message": {
+                "type": "string"
+              }
+            }
+          },
+          "warning": {
+            "type": "nested",
+            "properties": {
+              "keyword": {
+                "type": "string"
+              },
+              "dataPath": {
+                "type": "string"
+              },
+              "schemaPath": {
+                "type": "string"
+              },
+              "params": {
+                "type": "object"
+              },
+              "message": {
+                "type": "string"
+              }
+            }
+          },
+          "enhancements": {
+            "type": "nested",
+            "properties": {
+              "keyword": {
+                "type": "string"
+              },
+              "dataPath": {
+                "type": "string"
+              },
+              "schemaPath": {
+                "type": "string"
+              },
+              "params": {
+                "type": "object"
+              },
+              "message": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "fallback_used": {
+        "type": "boolean"
+      }
+    }
+  }
+}

--- a/schemas/repo/2.0.1/enhanced.json
+++ b/schemas/repo/2.0.1/enhanced.json
@@ -1,0 +1,260 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name of the release."
+    },
+    "version": {
+      "type": "string",
+      "description": "The version for this release. For example, '1.0.0'."
+    },
+    "organization": {
+      "type": "string",
+      "description": "The organization or component within the agency to which the releases listed belong. For example, '18F' or 'Navy'."
+    },
+    "description": {
+      "type": "string",
+      "description": "A one- or two-sentence description of the release."
+    },
+    "permissions": {
+      "type": "object",
+      "properties": {
+        "licenses": {
+          "type": ["array", "null"],
+          "items": {
+            "type": "object",
+            "properties": {
+              "URL": {
+                "type": "string",
+                "format": "uri",
+                "description": "The URL of the release license, if available. If not, null should be used."
+              },
+              "name": {
+                "type": "string",
+                "description": "An abbreviation for the name of the license. For example, 'CC0' or 'MIT'."
+              }
+            }
+          }
+        },
+        "usageType": {
+          "type": "string",
+          "description": "A list of enumerated values which describes the usage permissions for the release.",
+          "enum": [
+            "openSource",
+            "governmentWideReuse",
+            "exemptByLaw",
+            "exemptByNationalSecurity",
+            "exemptByAgencySystem",
+            "exemptByAgencyMission",
+            "exemptByCIO"
+          ]
+        },
+        "exemptionText": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "If an exemption is listed in the 'usageType' field, this field should include a one- or two- sentence justification for the exemption used."
+        }
+      },
+      "required": ["licenses"]
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "description": "An array of keywords that will be helpful in discovering and searching for the release."
+      }
+    },
+    "contact": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string",
+          "description": "The email address for the point of contact for the release."
+
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the point of contact for the release."
+
+        },
+        "URL": {
+          "type": "string",
+          "format": "uri",
+          "description": "The URL to a website that can be used to reach the point of contact. For example, 'http://twitter.com/codeDotGov'."
+        },
+        "phone": {
+          "type": "string",
+          "description": "A phone number for the point of contact for the release."
+        }
+      },
+      "required": ["email"]
+    },
+    "status": {
+      "type": "string",
+      "description": "The development status of the release.",
+      "enum": [
+        "Ideation",
+        "Development",
+        "Alpha",
+        "Beta",
+        "Release Candidate",
+        "Production",
+        "Archival"
+      ]
+    },
+    "vcs": {
+      "type": "string",
+      "description": "A lowercase string with the name of the version control system that is being used for the release. For example, 'git'."
+    },
+    "repositoryURL": {
+      "type": ["string", "null"],
+      "format": "uri",
+      "description": "The URL of the public release repository for open source repositories. This field is not required for repositories that are only available as government-wide reuse or are closed (pursuant to one of the exemptions)."
+    },
+    "target_operating_systems": {
+      "description": "A list of compatible operating systems where this project has been tested.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "Unix",
+          "Linux",
+          "Windows",
+          "MacOs",
+          "Other"
+        ]
+      }
+    },
+    "homepageURL": {
+      "type": "string",
+      "format": "uri",
+      "description": "The URL of the public release homepage."
+    },
+    "downloadURL": {
+      "type": "string",
+      "format": "uri",
+      "description": "The URL where a distribution of the release can be found."
+    },
+    "disclaimerURL": {
+      "type": "string",
+      "format": "uri",
+      "description": "The URL where disclaimer language regarding the release can be found."
+    },
+    "disclaimerText": {
+      "type": "string",
+      "description": "Short paragraph that includes disclaimer language to accompany the release."
+    },
+    "languages": {
+      "type": "array",
+      "description": " An array of strings with the names of the programming languages in use on the release.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "laborHours": {
+      "type": "number",
+      "description": "An estimate of total labor hours spent by your organization/component across all versions of this release. This includes labor performed by federal employees and contractors."
+    },
+    "relatedCode": {
+      "type": "array",
+      "description": "An array of affiliated government repositories that may be a part of the same project. For example,  relatedCode for 'code-gov-web' would include 'code-gov-api' and 'code-gov-tools'.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the code repository, project, library or release."
+          },
+          "URL": {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL where the code repository, project, library or release can be found."
+          }
+
+        },
+        "additionalProperties": false
+      }
+    },
+    "reusedCode": {
+      "type": "array",
+      "description": "An array of government source code, libraries, frameworks, APIs, platforms or other software used in this release. For example, US Web Design Standards, cloud.gov, Federalist, Digital Services Playbook, Analytics Reporter.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the software used in this release."
+          },
+          "URL": {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL where the software can be found."
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "partners": {
+      "type": "array",
+      "description": "An array of objects including an acronym for each agency partnering on the release and the contact email at such agency.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The acronym describing the partner agency."
+          },
+          "email": {
+            "type": "string",
+            "description": "The email address for the point of contact at the partner agency."
+          }
+        }
+      }
+    },
+    "additional_information": {
+      "type": "object",
+      "description": "An object that serves as a 'bucket' for additional information about the repository/project. This should not be used for internal data like database IDs or private notes.",
+      "properties": {
+        "additional_notes": {
+          "type": "string",
+          "description": "Additional notes or instructions that would make using this repo easier."
+        }
+      },
+      "additionalProperties": true
+    },
+    "date": {
+      "type": "object",
+      "description": "A date object describing the release.",
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date",
+          "description": "The date the release was created, in YYYY-MM-DD or ISO 8601 format."
+        },
+        "lastModified": {
+          "type": "string",
+          "format": "date",
+          "description": "The date the release was modified, in YYYY-MM-DD or ISO 8601 format."
+        },
+        "metadataLastUpdated": {
+          "type": "string",
+          "format": "date",
+          "description": "The date the metadata of the release was last updated, in YYYY-MM-DD or ISO 8601 format."
+        }
+      }
+    }
+  },
+  "required": [
+    "name",
+    "permissions",
+    "repositoryURL",
+    "description",
+    "laborHours",
+    "tags",
+    "contact"
+  ]
+}

--- a/schemas/repo/2.0.1/relaxed.json
+++ b/schemas/repo/2.0.1/relaxed.json
@@ -1,0 +1,220 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name of the release."
+    },
+    "version": {
+      "type": ["string", "null"],
+      "description": "The version for this release. For example, '1.0.0'."
+    },
+    "organization": {
+      "type": ["string", "null"],
+      "description": "The organization or component within the agency to which the releases listed belong. For example, '18F' or 'Navy'."
+    },
+    "description": {
+      "type": "string",
+      "description": "A one- or two-sentence description of the release."
+    },
+    "permissions": {
+      "type": "object",
+      "properties": {
+        "licenses": {
+          "type": ["array", "null"],
+          "items": {
+            "type": "object",
+            "properties": {
+              "URL": {
+                "type": ["string", "null"],
+                "description": "The URL of the release license, if available. If not, null should be used."
+              },
+              "name": {
+                "type": "string",
+                "description": "An abbreviation for the name of the license. For example, 'CC0' or 'MIT'."
+              }
+            },
+            "required": ["name"]
+          }
+        },
+        "usageType": {
+          "type": "string",
+          "description": "A list of enumerated values which describes the usage permissions for the release.",
+          "enum": [
+            "openSource",
+            "governmentWideReuse",
+            "exemptByLaw",
+            "exemptByNationalSecurity",
+            "exemptByAgencySystem",
+            "exemptByAgencyMission",
+            "exemptByCIO"
+          ],
+          "additionalProperties": false
+        },
+        "exemptionText": {
+          "type": ["string", "null"],
+          "description": "If an exemption is listed in the 'usageType' field, this field should include a one- or two- sentence justification for the exemption used."
+        }
+      },
+      "required": ["licenses", "usageType"]
+    },
+    "tags": {
+      "type": ["array", "null"],
+      "items": {
+        "type": "string",
+        "description": "An array of keywords that will be helpful in discovering and searching for the release."
+      }
+    },
+    "contact": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string",
+          "description": "The email address for the point of contact for the release."
+
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the point of contact for the release."
+
+        },
+        "URL": {
+          "type": "string",
+          "description": "The URL to a website that can be used to reach the point of contact. For example, 'http://twitter.com/codeDotGov'."
+        },
+        "phone": {
+          "type": "string",
+          "description": "A phone number for the point of contact for the release."
+        }
+      },
+      "required": ["email"]
+    },
+    "status": {
+      "type": ["string", "null"],
+      "description": "The development status of the release.",
+      "enum": [
+        "Ideation",
+        "Development",
+        "Alpha",
+        "Beta",
+        "Release Candidate",
+        "Production",
+        "Archival"
+      ]
+    },
+    "vcs": {
+      "type": ["string", "null"],
+      "description": "A lowercase string with the name of the version control system that is being used for the release. For example, 'git'."
+    },
+    "repositoryURL": {
+      "type": "string",
+      "description": "The URL of the public release repository for open source repositories. This field is not required for repositories that are only available as government-wide reuse or are closed (pursuant to one of the exemptions)."
+    },
+    "homepageURL": {
+      "type": ["string", "null"],
+      "description": "The URL of the public release homepage."
+    },
+    "downloadURL": {
+      "type": ["string", "null"],
+      "description": "The URL where a distribution of the release can be found."
+    },
+    "disclaimerURL": {
+      "type": ["string", "null"],
+      "description": "The URL where disclaimer language regarding the release can be found."
+    },
+    "disclaimerText": {
+      "type": ["string", "null"],
+      "description": "Short paragraph that includes disclaimer language to accompany the release."
+    },
+    "languages": {
+      "type": ["array", "null"],
+      "description": " An array of strings with the names of the programming languages in use on the release.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "laborHours": {
+      "type": "number",
+      "description": "An estimate of total labor hours spent by your organization/component across all versions of this release. This includes labor performed by federal employees and contractors."
+    },
+    "relatedCode": {
+      "type": ["array", "null"],
+      "description": "An array of affiliated government repositories that may be a part of the same project. For example,  relatedCode for 'code-gov-web' would include 'code-gov-api' and 'code-gov-tools'.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": ["string", "null"],
+            "description": "The name of the code repository, project, library or release."
+          },
+          "URL": {
+            "type": ["string", "null"],
+            "description": "The URL where the code repository, project, library or release can be found."
+          }
+        }
+      }
+    },
+    "reusedCode": {
+      "type": ["array", "null"],
+      "description": "An array of government source code, libraries, frameworks, APIs, platforms or other software used in this release. For example, US Web Design Standards, cloud.gov, Federalist, Digital Services Playbook, Analytics Reporter.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": ["string", "null"],
+            "description": "The name of the software used in this release."
+          },
+          "URL": {
+            "type": ["string", "null"],
+            "description": "The URL where the software can be found."
+          }
+        }
+      }
+    },
+    "partners": {
+      "type": ["array", "null"],
+      "description": "An array of objects including an acronym for each agency partnering on the release and the contact email at such agency.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": ["string", "null"],
+            "description": "The acronym describing the partner agency."
+          },
+          "email": {
+            "type": ["string", "null"],
+            "description": "The email address for the point of contact at the partner agency."
+          }
+        }
+      }
+    },
+    "date": {
+      "type": ["object", "null"],
+      "description": "A date object describing the release.",
+      "properties": {
+        "created": {
+          "type": ["string", "null"],
+          "description": "The date the release was created, in YYYY-MM-DD or ISO 8601 format."
+        },
+        "lastModified": {
+          "type": ["string", "null"],
+          "description": "The date the release was modified, in YYYY-MM-DD or ISO 8601 format."
+        },
+        "metadataLastUpdated": {
+          "type": ["string", "null"],
+          "description": "The date the metadata of the release was last updated, in YYYY-MM-DD or ISO 8601 format."
+        }
+      }
+    }
+  },
+  "required": [
+    "name",
+    "permissions",
+    "repositoryURL",
+    "description",
+    "laborHours",
+    "tags",
+    "contact"
+  ]
+}

--- a/schemas/repo/2.0.1/strict.json
+++ b/schemas/repo/2.0.1/strict.json
@@ -1,0 +1,263 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name of the release."
+    },
+    "version": {
+      "type": "string",
+      "description": "The version for this release. For example, '1.0.0'."
+    },
+    "organization": {
+      "type": "string",
+      "description": "The organization or component within the agency to which the releases listed belong. For example, '18F' or 'Navy'."
+    },
+    "description": {
+      "type": "string",
+      "description": "A one or two sentence description of the release."
+    },
+    "permissions": {
+      "type": "object",
+      "properties": {
+        "licenses": {
+          "type": ["array", "null"],
+          "items": {
+            "type": "object",
+            "properties": {
+              "URL": {
+                "type": "string",
+                "format": "uri",
+                "description": "The URL of the release license, if available. If not, null should be used."
+              },
+              "name": {
+                "type": "string",
+                "description": "An abbreviation for the name of the license. For example, 'CC0' or 'MIT'."
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "usageType": {
+          "type": "string",
+          "description": "A list of enumerated values which describes the usage permissions for the release.",
+          "enum": [
+            "openSource",
+            "governmentWideReuse",
+            "exemptByLaw",
+            "exemptByNationalSecurity",
+            "exemptByAgencySystem",
+            "exemptByAgencyMission",
+            "exemptByCIO"
+          ],
+          "additionalProperties": false
+        },
+        "exemptionText": {
+          "type": ["string", "null"],
+          "description": "If an exemption is listed in the 'usageType' field, this field should include a one- or two- sentence justification for the exemption used."
+        }
+      },
+      "additionalProperties": false,
+      "required": ["licenses"]
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "description": "An array of keywords that will be helpful in discovering and searching for the release."
+      }
+    },
+    "contact": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string",
+          "description": "The email address for the point of contact for the release."
+
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the point of contact for the release."
+
+        },
+        "URL": {
+          "type": "string",
+          "format": "uri",
+          "description": "The URL to a website that can be used to reach the point of contact. For example, 'http://twitter.com/codeDotGov'."
+        },
+        "phone": {
+          "type": "string",
+          "description": "A phone number for the point of contact for the release."
+        }
+      },
+      "additionalProperties": false,
+      "required": ["email"]
+    },
+    "status": {
+      "type": "string",
+      "description": "The development status of the release.",
+      "enum": [
+        "Ideation",
+        "Development",
+        "Alpha",
+        "Beta",
+        "Release Candidate",
+        "Production",
+        "Archival"
+      ]
+    },
+    "vcs": {
+      "type": "string",
+      "description": "A lowercase string with the name of the version control system that is being used for the release. For example, 'git'."
+    },
+    "repositoryURL": {
+      "type": "string",
+      "format": "uri",
+      "description": "The URL of the public release repository for open source repositories. This field is not required for repositories that are only available as government-wide reuse or are closed (pursuant to one of the exemptions)."
+    },
+    "targetOperatingSystems": {
+      "description": "A list of compatible operating systems where this project has been tested.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "Unix",
+          "Linux",
+          "Windows",
+          "MacOs",
+          "Other"
+        ]
+      }
+    },
+    "homepageURL": {
+      "type": "string",
+      "format": "uri",
+      "description": "The URL of the public release homepage."
+    },
+    "downloadURL": {
+      "type": "string",
+      "format": "uri",
+      "description": "The URL where a distribution of the release can be found."
+    },
+    "disclaimerURL": {
+      "type": "string",
+      "format": "uri",
+      "description": "The URL where disclaimer language regarding the release can be found."
+    },
+    "disclaimerText": {
+      "type": "string",
+      "description": "Short paragraph that includes disclaimer language to accompany the release."
+    },
+    "languages": {
+      "type": "array",
+      "description": " An array of strings with the names of the programming languages in use on the release.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "laborHours": {
+      "type": "number",
+      "description": "An estimate of total labor hours spent by your organization/component across all versions of this release. This includes labor performed by federal employees and contractors."
+    },
+    "relatedCode": {
+      "type": "array",
+      "description": "An array of affiliated government repositories that may be a part of the same project. For example,  relatedCode for 'code-gov-web' would include 'code-gov-api' and 'code-gov-tools'.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the code repository, project, library or release."
+          },
+          "URL": {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL where the code repository, project, library or release can be found."
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "reusedCode": {
+      "type": "array",
+      "description": "An array of government source code, libraries, frameworks, APIs, platforms or other software used in this release. For example, US Web Design Standards, cloud.gov, Federalist, Digital Services Playbook, Analytics Reporter.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the software used in this release."
+          },
+          "URL": {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL where the software can be found."
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "partners": {
+      "type": "array",
+      "description": "An array of objects including an acronym for each agency partnering on the release and the contact email at such agency.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The acronym describing the partner agency."
+          },
+          "email": {
+            "type": "string",
+            "description": "The email address for the point of contact at the partner agency."
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "additionalInformation": {
+      "type": "object",
+      "description": "An object that serves as a 'bucket' for additional information about the repository/project. This should not be used for internal data like database IDs or private notes.",
+      "properties": {
+        "additionalNotes": {
+          "type": ["string", "null"],
+          "description": "Additional notes or instructions that would make using this repo easier."
+        }
+      },
+      "additionalProperties": true
+    },
+    "date": {
+      "type": "object",
+      "description": "A date object describing the release.",
+      "properties": {
+        "created": {
+          "type": "string",
+          "format": "date",
+          "description": "The date the release was created, in YYYY-MM-DD or ISO 8601 format."
+        },
+        "lastModified": {
+          "type": "string",
+          "format": "date",
+          "description": "The date the release was modified, in YYYY-MM-DD or ISO 8601 format."
+        },
+        "metadataLastUpdated": {
+          "type": "string",
+          "format": "date",
+          "description": "The date the metadata of the release was last updated, in YYYY-MM-DD or ISO 8601 format."
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "name",
+    "permissions",
+    "repositoryURL",
+    "description",
+    "laborHours",
+    "tags",
+    "contact"
+  ]
+}

--- a/services/formatter/index.js
+++ b/services/formatter/index.js
@@ -78,7 +78,7 @@ class Formatter {
       : ['other'];
     repo.additionalInformation = repo.additionalInformation
       ? repo.additionalInformation
-      : { additionalNotes: null }
+      : { additionalNotes: null };
   }
   _upgradeToPermissions(repo) {
 

--- a/services/searcher/index.js
+++ b/services/searcher/index.js
@@ -3,7 +3,7 @@ const Bodybuilder         = require("bodybuilder");
 const moment              = require("moment");
 const Utils               = require("../../utils");
 const Logger              = require("../../utils/logger");
-const repoMapping         = require("../../indexes/repo/mapping_200.json");
+const repoMapping         = require("../../indexes/repo/mapping_201.json");
 
 const DATE_FORMAT = "YYYY-MM-DD";
 const REPO_RESULT_SIZE_MAX = 10000;

--- a/test/unit/services/indexer/repo/agencyJsonStream.test.js
+++ b/test/unit/services/indexer/repo/agencyJsonStream.test.js
@@ -98,6 +98,10 @@ describe('AgencyJsonStream', function() {
         URL: '',
         name: ''
       }],
+      targetOperatingSystems: ['other'],
+      additionalInformation: {
+        additionalNotes: null
+      },
       date: {
         created: '',
         lastModified: moment('2017-04-11', 'YYYY-MM-DD').utc().toJSON(),


### PR DESCRIPTION
**Summary**

Adds new fields and support for schema 2.0.1

This PR fixes/implements the following **bugs/features**

* [x] Feature #224 

Explain the **motivation** for making this change. What existing problem does the pull request solve?

A number of agencies expressed interest in having a "meta-data" field that would let them add any additional information they deemed necessary. The first agency to give us a concrete answer to this feature was NIH. 

As part of our support to our partner agencies, we've added new __optional__fields:

* targetOperatingSystems - An ENUME of the "common" OS's out there
* additionalInformation - a dynamic object field that would let users add any additional information they feel is necessary for a particular repository.

**Test plan (required)**

<img width="488" alt="image" src="https://user-images.githubusercontent.com/1918027/41999109-985a291e-7a2a-11e8-88e0-4a082bcdc27a.png">

**Closing issues**

Closes #224 