### PR TITLE
Correcting the FEC title, Commission - not Comissions.

### DIFF
--- a/config/agency_metadata.json
+++ b/config/agency_metadata.json
@@ -447,7 +447,7 @@
     "complianceDashboard": false
   }, {
     "id": 30,
-    "name": "Federal Elections Commission",
+    "name": "Federal Election Commission",
     "acronym": "FEC",
     "website": "https://www.fec.gov/",
     "codeUrl": "https://www.fec.gov/code.json",


### PR DESCRIPTION
@froi  correcting the agency name to "Federal Election Commission", 
(Not "Federal Election**s** Commission)
It was my original typo. sorry. 

