### PR TITLE
Logger level is now set with environment variable

### DIFF
--- a/utils/logger.js
+++ b/utils/logger.js
@@ -15,7 +15,7 @@ module.exports = class Logger {
     }
     let bun = bunyan.createLogger({
       name: config.name,
-      level: config.LOGGER_LEVEL || 'info',
+      level: process.env.LOGGER_LEVEL || config.LOGGER_LEVEL || 'info',
       serializers: {
         req: Utils.getLoggerRequestSerializer,
         res: Utils.getLoggerResponseSerializer,


### PR DESCRIPTION
**Summary**

Logger level is now set with an environment variable

Explain the **motivation** for making this change. What existing problem does the pull request solve?

All loggers should have the same level through the process. Using an environment variable lets us change the value easier than in a config file.

**Test plan (required)**

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
