### PR TITLE
Fetch metadata file from remote source

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -41,9 +41,15 @@ function getPort(cloudFoundryEnv={}) {
  * @returns {object} - Directory paths needed by the application
  */
 function getAppFilesDirectories() {
-  const filePath = process.env.NODE_ENV === 'testing'
-    ? path.join(path.dirname(__dirname), 'config/testing_agency_metadata.json')
-    : path.join(path.dirname(__dirname), 'config/agency_metadata.json');
+  let filePath;
+
+  if(process.env.GET_REMOTE_METADATA && process.env.REMOTE_METADATA_LOCATION) {
+    filePath = process.env.REMOTE_METADATA_LOCATION;
+  } else {
+    filePath = process.env.NODE_ENV === 'testing'
+      ? path.join(path.dirname(__dirname), 'config/testing_agency_metadata.json')
+      : path.join(path.dirname(__dirname), 'config/agency_metadata.json');
+  }
 
   return {
     AGENCY_ENDPOINTS_FILE: filePath,
@@ -118,6 +124,8 @@ function getConfig(env='development') {
   config.HSTS_PRELOAD = false;
   config.PORT = getPort(cloudFoundryEnv);
 
+  config.GET_REMOTE_METADATA = process.env.GET_REMOTE_METADATA && process.env.GET_REMOTE_METADATA === 'true';
+  config.GET_GITHUB_DATA = process.env.GET_GITHUB_DATA && process.env.GET_GITHUB_DATA === 'true';
   config.ES_HOST = getElasticsearchUri(cloudFoundryEnv);
 
   Object.assign(config, getAppFilesDirectories());

--- a/package-lock.json
+++ b/package-lock.json
@@ -164,8 +164,9 @@
       }
     },
     "@code.gov/code-gov-adapter": {
-      "version": "github:gsa/code-gov-adapters#204254b24c417db169675ee725c30e09ad30a018",
-      "from": "github:gsa/code-gov-adapters",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@code.gov/code-gov-adapter/-/code-gov-adapter-1.0.0.tgz",
+      "integrity": "sha512-l4yoNuku4ZdRjVDkGec1W0tFX7hPnIvOZ5xPYeqeNG7F4g1j1aIKc4BmqSyq0XGbhXcBo8sCiYT3aMYd2djojQ==",
       "requires": {
         "bodybuilder": "^2.2.15",
         "elasticsearch": "^15.1.1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "type": "git",
     "url": "https://github.com/GSA/code-gov-api.git"
   },
+  "license": "CC0-1.0",
   "scripts": {
     "start": "node app.js | ./node_modules/.bin/bunyan --color",
     "debug": "node --inspect app.js | ./node_modules/.bin/bunyan --color",
@@ -25,7 +26,7 @@
     "security-check": "./node_modules/.bin/nsp check"
   },
   "dependencies": {
-    "@code.gov/code-gov-adapter": "github:gsa/code-gov-adapters",
+    "@code.gov/code-gov-adapter": "^1.0.0",
     "@code.gov/code-gov-integrations": "github:gsa/code-gov-integrations",
     "@code.gov/code-gov-validator": "^1.0.0",
     "JSONStream": "^1.3.1",

--- a/scripts/index/repo/index.js
+++ b/scripts/index/repo/index.js
@@ -43,7 +43,9 @@ class Indexer {
     try {
       const repoIndexInfo = await RepoIndexer.init(this.elasticsearchAdapter, this.config);
       await normalizeRepoScores(this.elasticsearchAdapter, repoIndexInfo);
-      await getGithubData(this.elasticsearchAdapter, repoIndexInfo);
+      if(this.config.GET_GITHUB_DATA) {
+        await getGithubData(this.elasticsearchAdapter, repoIndexInfo);
+      }
       await IndexOptimizer.init(this.elasticsearchAdapter, repoIndexInfo, this.config);
       await AliasSwapper.init(this.elasticsearchAdapter, repoIndexInfo, this.config);
       await IndexCleaner.init(this.elasticsearchAdapter, repoIndexInfo.esAlias, DAYS_TO_KEEP, this.config);

--- a/services/indexer/repo/index.js
+++ b/services/indexer/repo/index.js
@@ -2,6 +2,7 @@ const fs = require("fs");
 const JSONStream = require("JSONStream");
 const Reporter = require("../../reporter");
 const AbstractIndexer = require("../abstract_indexer");
+const fetch = require('node-fetch');
 
 const AgencyJsonStream = require("../repo/AgencyJsonStream");
 const RepoIndexerStream = require("../repo/RepoIndexStream");
@@ -30,8 +31,20 @@ class RepoIndexer extends AbstractIndexer {
 
   }
 
-  indexRepos(config) {
-    const agencyEndpointsStream = fs.createReadStream(this.agencyEndpointsFile);
+  async getMetadata() {
+    let response;
+
+    if(process.env.GET_REMOTE_METADATA) {
+      response = await fetch(this.agencyEndpointsFile);
+      return response.body;
+    }
+
+    return fs.createReadStream(this.agencyEndpointsFile);
+  }
+
+  async indexRepos(config) {
+
+    const agencyEndpointsStream = await this.getMetadata();
     const jsonStream = JSONStream.parse("*");
     const agencyJsonStream = new AgencyJsonStream(this.fetchedFilesDir, this.fallbackFilesDir, config);
     const indexerStream = new RepoIndexerStream(this);


### PR DESCRIPTION
**Summary**

- Added new environment variables to indicate that metadata fetch should be done from remote URL. Variables are GET_REMOTE_METADATA and REMOTE_METADATA_LOCATION. These can be found in the config file.
- Added GET_GITHUB_DATA environment variable to toggle the collection of Github data.
- Added getMetaData helper function to RepoIndexer. This function fetches metadata file form remote URL or local file system.
- Added the use of code-gov-adapters v1.0.0 from NPM.

Explain the **motivation** for making this change. What existing problem does the pull request solve?

We wanted to update the metadata file without having to deploy the API or harvester every time it was done. This will also let us update the file on its own inside a version control system.