### PR TITLE
Minor version handling updates

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -113,10 +113,11 @@ function getConfig(env='development') {
     "tags",
     "languages"];
   config.supportedSchemaVersions = [
-    '1.0.0',
     '1.0.1',
+    '2.0',
     '2.0.0'
   ];
+  config.UPDATE_REPO_REGEX = /(1\.0)(\.\d)?/;
   config.GITHUB_TOKEN = process.env.GITHUB_TOKEN || null;
   config.GITHUB_AUTH_TYPE = process.env.GITHUB_AUTH_TYPE || 'token';
   config.USE_HSTS = process.env.USE_HSTS ? process.env.USE_HSTS === 'true' : config.isProd;

--- a/data/fetched/EOP.json
+++ b/data/fetched/EOP.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.1",
+  "version": "2.0.0",
   "agency": "EOP",
   "releases": [
     {

--- a/data/fetched/NSF.json
+++ b/data/fetched/NSF.json
@@ -29,8 +29,8 @@
       "permissions": {
         "licenses": [
           {
-            "URL": "https://www.nsf.gov/digitalstrategy/Alternative_Analysis_Report_Template_Process.pdf",
-            "name": "NSF"
+            "URL": "https://github.com/nsf-open/nsf-common-ember-components/blob/master/LICENSE",
+            "name": "GPL.v3"
           }
         ],
         "usageType": "openSource"
@@ -68,8 +68,8 @@
       "permissions": {
         "licenses": [
           {
-            "URL": "https://www.nsf.gov/digitalstrategy/Alternative_Analysis_Report_Template_Process.pdf",
-            "name": "NSF"
+            "URL": "https://github.com/nsf-open/nsf-ember-tooltip/blob/master/LICENSE",
+            "name": "GPL.v3"
           }
         ],
         "usageType": "openSource"
@@ -111,7 +111,7 @@
           }
         ],
         "usageType": "exemptByAgencySystem",
-        "ExemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
+        "exemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
       },
       "laborHours": -1,
       "date": {
@@ -151,7 +151,7 @@
           }
         ],
         "usageType": "exemptByAgencySystem",
-        "ExemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
+        "exemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
       },
       "laborHours": -1,
       "date": {
@@ -198,7 +198,7 @@
           }
         ],
         "usageType": "exemptByAgencySystem",
-        "ExemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
+        "exemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
       },
       "laborHours": -1,
       "date": {
@@ -238,7 +238,7 @@
           }
         ],
         "usageType": "exemptByAgencySystem",
-        "ExemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
+        "exemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
       },
       "laborHours": -1,
       "date": {
@@ -278,7 +278,7 @@
           }
         ],
         "usageType": "exemptByAgencySystem",
-        "ExemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
+        "exemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
       },
       "laborHours": -1,
       "date": {
@@ -318,7 +318,7 @@
           }
         ],
         "usageType": "exemptByAgencySystem",
-        "ExemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
+        "exemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
       },
       "laborHours": -1,
       "date": {
@@ -358,7 +358,7 @@
           }
         ],
         "usageType": "exemptByAgencySystem",
-        "ExemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
+        "exemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
       },
       "laborHours": -1,
       "date": {
@@ -389,16 +389,54 @@
       "languages": [
         "Java"
       ],
-      "repositoryURL": "",
+      "repositoryURL": "https://github.com/nsf-open/rest-service-proposal-data",
       "permissions": {
         "licenses": [
           {
-            "URL": "https://www.nsf.gov/digitalstrategy/Alternative_Analysis_Report_Template_Process.pdf",
-            "name": "NSF"
+            "URL": "https://github.com/nsf-open/rest-service-proposal-data/blob/master/LICENSE",
+            "name": "GPL.v3"
           }
         ],
-        "usageType": "exemptByAgencySystem",
-        "ExemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
+        "usageType": "openSource"
+      },
+      "laborHours": -1,
+      "date": {
+        "created": "",
+        "lastModified": "",
+        "metadataLastUpdated": ""
+      },
+      "vcs": "",
+      "disclaimerText": "",
+      "disclaimerURL": ""
+    },
+    {
+      "name": "nsf-ember-psm",
+      "description": "Contains javascript front-end for NSF's new proposal submission system.",
+      "tags": [
+        "javascript",
+        "government",
+        "ember",
+        "nsf",
+        "psm",
+        "external"
+      ],
+      "contact": {
+        "email": "esivagna@nsf.gov",
+        "name": "Elanchezhian Sivagnanam",
+        "phone": "7032928088"
+      },
+      "languages": [
+        "JavaScript"
+      ],
+      "repositoryURL": "https://github.com/nsf-open/nsf-ember-psm",
+      "permissions": {
+        "licenses": [
+          {
+            "URL": "https://github.com/nsf-open/nsf-ember-psm/blob/master/LICENSE",
+            "name": "GPL.v3"
+          }
+        ],
+        "usageType": "openSource"
       },
       "laborHours": -1,
       "date": {
@@ -439,7 +477,7 @@
           }
         ],
         "usageType": "exemptByAgencySystem",
-        "ExemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
+        "exemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
       },
       "laborHours": -1,
       "date": {
@@ -470,16 +508,15 @@
       "languages": [
         "Java"
       ],
-      "repositoryURL": "",
+      "repositoryURL": "https://github.com/nsf-open/rest-service-solicitation-data",
       "permissions": {
         "licenses": [
           {
-            "URL": "https://www.nsf.gov/digitalstrategy/Alternative_Analysis_Report_Template_Process.pdf",
-            "name": "NSF"
+            "URL": "https://github.com/nsf-open/rest-service-solicitation-data/blob/master/LICENSE",
+            "name": "GPL.v3"
           }
         ],
-        "usageType": "exemptByAgencySystem",
-        "ExemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
+        "usageType": "openSource"
       },
       "laborHours": -1,
       "date": {
@@ -510,16 +547,15 @@
       "languages": [
         "Java"
       ],
-      "repositoryURL": "",
+      "repositoryURL": "https://github.com/nsf-open/rest-service-proposal-management",
       "permissions": {
         "licenses": [
           {
-            "URL": "https://www.nsf.gov/digitalstrategy/Alternative_Analysis_Report_Template_Process.pdf",
-            "name": "NSF"
+            "URL": "https://github.com/nsf-open/rest-service-proposal-management/blob/master/LICENSE",
+            "name": "GPL.v3"
           }
         ],
-        "usageType": "exemptByAgencySystem",
-        "ExemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
+        "usageType": "openSource"
       },
       "laborHours": -1,
       "date": {
@@ -560,7 +596,7 @@
           }
         ],
         "usageType": "exemptByAgencySystem",
-        "ExemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
+        "exemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
       },
       "laborHours": -1,
       "date": {
@@ -601,7 +637,7 @@
           }
         ],
         "usageType": "exemptByAgencySystem",
-        "ExemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
+        "exemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
       },
       "laborHours": -1,
       "date": {
@@ -639,8 +675,8 @@
       "permissions": {
         "licenses": [
           {
-            "URL": "https://www.nsf.gov/digitalstrategy/Alternative_Analysis_Report_Template_Process.pdf",
-            "name": "NSF"
+            "URL": "https://github.com/nsf-open/rest-service-system-advisory/blob/master/LICENSE",
+            "name": "GPL.v3"
           }
         ],
         "usageType": "openSource"
@@ -680,8 +716,8 @@
       "permissions": {
         "licenses": [
           {
-            "URL": "https://www.nsf.gov/digitalstrategy/Alternative_Analysis_Report_Template_Process.pdf",
-            "name": "NSF"
+            "URL": "https://github.com/nsf-open/rest-service-email/blob/master/LICENSE",
+            "name": "GPL.v3"
           }
         ],
         "usageType": "openSource"
@@ -722,8 +758,8 @@
       "permissions": {
         "licenses": [
           {
-            "URL": "https://www.nsf.gov/digitalstrategy/Alternative_Analysis_Report_Template_Process.pdf",
-            "name": "NSF"
+            "URL": "https://github.com/nsf-open/rest-service-inbox/blob/master/LICENSE",
+            "name": "GPL.v3"
           }
         ],
         "usageType": "openSource"
@@ -766,7 +802,7 @@
           }
         ],
         "usageType": "exemptByAgencySystem",
-        "ExemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
+        "exemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
       },
       "laborHours": -1,
       "date": {
@@ -804,8 +840,8 @@
       "permissions": {
         "licenses": [
           {
-            "URL": "https://www.nsf.gov/digitalstrategy/Alternative_Analysis_Report_Template_Process.pdf",
-            "name": "NSF"
+            "URL": "https://github.com/nsf-open/rest-service-toggle/blob/master/LICENSE",
+            "name": "GPL.v3"
           }
         ],
         "usageType": "openSource"
@@ -838,16 +874,93 @@
       "languages": [
         "Java"
       ],
-      "repositoryURL": "",
+      "repositoryURL": "https://github.com/nsf-open/rest-service-document-generation",
       "permissions": {
         "licenses": [
           {
-            "URL": "https://www.nsf.gov/digitalstrategy/Alternative_Analysis_Report_Template_Process.pdf",
-            "name": "NSF"
+            "URL": "https://github.com/nsf-open/rest-service-document-generation/blob/master/LICENSE",
+            "name": "GPL.v3"
           }
         ],
-        "usageType": "exemptByAgencySystem",
-        "ExemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
+        "usageType": "openSource"
+      },
+      "laborHours": -1,
+      "date": {
+        "created": "",
+        "lastModified": "",
+        "metadataLastUpdated": ""
+      },
+      "vcs": "",
+      "disclaimerText": "",
+      "disclaimerURL": ""
+    },
+    {
+      "name": "document-compliance-service",
+      "description": "Service retrieves document attributes and metadata for compliance checks.",
+      "tags": [
+        "java",
+        "government",
+        "microservice",
+        "nsf",
+        "psm",
+        "external"
+      ],
+      "contact": {
+        "email": "esivagna@nsf.gov",
+        "name": "Elanchezhian Sivagnanam",
+        "phone": "7032928088"
+      },
+      "languages": [
+        "Java"
+      ],
+      "repositoryURL": "https://github.com/nsf-open/rest-service-document-compliance",
+      "permissions": {
+        "licenses": [
+          {
+            "URL": "https://github.com/nsf-open/rest-service-document-compliance/blob/master/LICENSE",
+            "name": "GPL.v3"
+          }
+        ],
+        "usageType": "openSource"
+      },
+      "laborHours": -1,
+      "date": {
+        "created": "",
+        "lastModified": "",
+        "metadataLastUpdated": ""
+      },
+      "vcs": "",
+      "disclaimerText": "",
+      "disclaimerURL": ""
+    },
+    {
+      "name": "compliance-validation-service",
+      "description": "Checks proposal compliance to rules and policies",
+      "tags": [
+        "java",
+        "government",
+        "microservice",
+        "nsf",
+        "psm",
+        "external"
+      ],
+      "contact": {
+        "email": "esivagna@nsf.gov",
+        "name": "Elanchezhian Sivagnanam",
+        "phone": "7032928088"
+      },
+      "languages": [
+        "Java"
+      ],
+      "repositoryURL": "https://github.com/nsf-open/rest-service-compliance-validation",
+      "permissions": {
+        "licenses": [
+          {
+            "URL": "https://github.com/nsf-open/rest-service-compliance-validation/blob/master/LICENSE",
+            "name": "GPL.v3"
+          }
+        ],
+        "usageType": "openSource"
       },
       "laborHours": -1,
       "date": {
@@ -878,16 +991,15 @@
       "languages": [
         "Java"
       ],
-      "repositoryURL": "",
+      "repositoryURL": "https://github.com/nsf-open/rest-service-file-storage",
       "permissions": {
         "licenses": [
           {
-            "URL": "https://www.nsf.gov/digitalstrategy/Alternative_Analysis_Report_Template_Process.pdf",
-            "name": "NSF"
+            "URL": "https://github.com/nsf-open/rest-service-file-storage/blob/master/LICENSE",
+            "name": "GPL.v3"
           }
         ],
-        "usageType": "exemptByAgencySystem",
-        "ExemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
+        "usageType": "openSource"
       },
       "laborHours": -1,
       "date": {
@@ -927,7 +1039,7 @@
           }
         ],
         "usageType": "exemptByAgencySystem",
-        "ExemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
+        "exemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
       },
       "laborHours": -1,
       "date": {
@@ -941,7 +1053,7 @@
     },
     {
       "name": "get-user-data-service",
-      "description": "Service retrieves the user profile attribute and the access details.  By default, the Get User data service returns the given userâ€™s attribute list.  Applications that intend to request the access details (functional organization, associated program elements, role/entitlement etc.) should request the service with a filter org=true as a request parameter. The Access Details object includes the list of functional organizations with their associated program elements and roles for the given user.",
+      "description": "Service retrieves the user profile attribute and the access details.  By default, the Get User data service returns the given userÃ¢â‚¬â„¢s attribute list.  Applications that intend to request the access details (functional organization, associated program elements, role/entitlement etc.) should request the service with a filter org=true as a request parameter. The Access Details object includes the list of functional organizations with their associated program elements and roles for the given user.",
       "tags": [
         "java",
         "government",
@@ -967,7 +1079,7 @@
           }
         ],
         "usageType": "exemptByAgencySystem",
-        "ExemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
+        "exemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
       },
       "laborHours": -1,
       "date": {
@@ -1007,7 +1119,7 @@
           }
         ],
         "usageType": "exemptByAgencySystem",
-        "ExemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
+        "exemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
       },
       "laborHours": -1,
       "date": {
@@ -1047,7 +1159,7 @@
           }
         ],
         "usageType": "exemptByAgencySystem",
-        "ExemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
+        "exemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
       },
       "laborHours": -1,
       "date": {
@@ -1087,7 +1199,7 @@
           }
         ],
         "usageType": "exemptByAgencySystem",
-        "ExemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
+        "exemptionText": "Internal system not suitable for open source. For example, database queries are stored in external stored procedures."
       },
       "laborHours": -1,
       "date": {

--- a/data/fetched/SBA.json
+++ b/data/fetched/SBA.json
@@ -105,6 +105,29 @@
       }
     },
     {
+      "name": "Small Business Voice User Interface",
+      "repositoryURL": "https://github.com/USSBA/sba-gov-vui",
+      "description": "Voice user interface prototype using SBA's Small Business Size Standards API",
+      "permissions": {
+        "licenses": [
+          {
+            "name": "Apache v2",
+            "URL": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        ],
+        "usageType": "openSource"
+      },
+      "vcs": "git",
+      "laborHours": 0,
+      "tags": [
+        "SBA",
+        "Serverless"
+      ],
+      "contact": {
+        "email": "Andrew.Davy@sba.gov"
+      }
+    },
+    {
       "name": "OracletoSQL",
       "repositoryURL": "https://github.com/USSBA/oracle2sql",
       "description": "A standalone CFM code to move data from Oracle Database to SQL Server Database.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -168,9 +168,9 @@
       }
     },
     "@code.gov/code-gov-adapter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@code.gov/code-gov-adapter/-/code-gov-adapter-1.0.0.tgz",
-      "integrity": "sha512-l4yoNuku4ZdRjVDkGec1W0tFX7hPnIvOZ5xPYeqeNG7F4g1j1aIKc4BmqSyq0XGbhXcBo8sCiYT3aMYd2djojQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@code.gov/code-gov-adapter/-/code-gov-adapter-1.0.1.tgz",
+      "integrity": "sha512-Ikps1oNyR1XUCV7xNA/MQEP/T5xsJT8UPecFDFDaZmLcEFWKPDBk8hMaI7OeJvckoR0FrdIpmgAmV6lHfOFRVg==",
       "requires": {
         "bodybuilder": "^2.2.15",
         "elasticsearch": "^15.1.1",
@@ -178,33 +178,10 @@
         "moment": "^2.22.2"
       },
       "dependencies": {
-        "bodybuilder": {
-          "version": "2.2.15",
-          "resolved": "https://registry.npmjs.org/bodybuilder/-/bodybuilder-2.2.15.tgz",
-          "integrity": "sha512-HfKzpjUeF9B/ISLivwhC02+75QzxLjZyv6QXUH+k4npH6UipkHCDIaI13+L0c42BBO0o4XwsZPRwasFI/ySDXA==",
-          "requires": {
-            "lodash": "^4.9.0"
-          }
-        },
-        "elasticsearch": {
-          "version": "15.1.1",
-          "resolved": "https://registry.npmjs.org/elasticsearch/-/elasticsearch-15.1.1.tgz",
-          "integrity": "sha512-Yr9xy10rUMjDty7qCys7X9AIW5+PX4Gtv2NksZqXIc+AZiWna/y2QwZdiSLtb5LTOKDp7PbegfuokhIjMHUpKw==",
-          "requires": {
-            "agentkeepalive": "^3.4.1",
-            "chalk": "^1.0.0",
-            "lodash": "^4.17.10"
-          }
-        },
         "lodash": {
           "version": "4.17.11",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
           "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-        },
-        "moment": {
-          "version": "2.22.2",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-          "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
         }
       }
     },
@@ -216,9 +193,9 @@
       }
     },
     "@code.gov/code-gov-validator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@code.gov/code-gov-validator/-/code-gov-validator-1.0.0.tgz",
-      "integrity": "sha512-7whZWYqZZTfvsL3JCUCYdgHqEhXZoexi7pTNZssFTgKMv0QXDm1anYo/CJ3jowRSwpRw+dZEk92N81OzozX0LA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@code.gov/code-gov-validator/-/code-gov-validator-1.0.1.tgz",
+      "integrity": "sha512-JkPwOTN7wjqtpbZLG84FqJ0PPy/cLEyinnjazeph4cnrInQqnAwUHegEQThUU4xr+cupPv92PHAioLPeW5fvOw==",
       "requires": {
         "ajv": "^6.5.2",
         "jsonfile": "^4.0.0",
@@ -226,27 +203,6 @@
         "simple-rules-engine": "^1.0.2"
       },
       "dependencies": {
-        "ajv": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
-          "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
-          "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.1"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
-        },
         "jsonfile": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "security-check": "./node_modules/.bin/nsp check"
   },
   "dependencies": {
-    "@code.gov/code-gov-adapter": "^1.0.0",
+    "@code.gov/code-gov-adapter": "^1.0.1",
     "@code.gov/code-gov-integrations": "github:gsa/code-gov-integrations",
-    "@code.gov/code-gov-validator": "^1.0.0",
+    "@code.gov/code-gov-validator": "^1.0.1",
     "JSONStream": "^1.3.5",
     "ajv": "^6.5.4",
     "body-parser": "^1.18.3",

--- a/services/formatter/index.js
+++ b/services/formatter/index.js
@@ -3,10 +3,12 @@ const Logger = require("../../utils/logger");
 const moment = require("moment");
 const path = require('path');
 const Utils = require("../../utils");
+const getConfig = require('../../config');
 
 class Formatter {
-  constructor() {
+  constructor(config) {
     this.logger = new Logger({ name: "formatter" });
+    this.config = config;
   }
 
   _formatDate(date) {
@@ -156,16 +158,15 @@ class Formatter {
     return repo;
   }
 
-  formatRepo(schemaVersion = '1.0.1', repo) {
+  formatRepo(schemaVersion = '2.0.0', repo) {
     return new Promise((resolve, reject) => {
       let formattedRepo;
       try {
-        if(schemaVersion === '2.0.0' || schemaVersion === '2.0.1') {
-          formattedRepo = this._formatRepo(repo);
-        } else {
+        if(schemaVersion.match(this.config.UPDATE_REPO_REGEX)) {
           this._upgradeProject(repo);
-          formattedRepo = this._formatRepo(repo);
         }
+
+        formattedRepo = this._formatRepo(repo);
 
         this.logger.debug('formatted repo', formattedRepo);
       } catch (error) {
@@ -180,4 +181,4 @@ class Formatter {
   }
 }
 
-module.exports = new Formatter();
+module.exports = new Formatter(getConfig(process.env.NODE_ENV));


### PR DESCRIPTION
**Summary**

Changed the way we handle some of the schema versions. `2.0` is now equivalent to `2.0.0` when it comes to harvesting and formatting code.json files.

Explain the **motivation** for making this change. What existing problem does the pull request solve?

Some of our partners (NSA) are using `2.0` as their schema version. While this is technically incorrect, we feel that it is similar enough to `2.0.0`. This way we ensure we harvest their data while they change their version number.