### PR TITLE
Fix agencies endpoint bug - part 2

### DIFF
--- a/routes/routes.js
+++ b/routes/routes.js
@@ -112,7 +112,7 @@ function getApiRoutes(config, router) {
   });
   router.get(`/agencies`, async (request, response, next) => {
     try {
-      const agenciesMetaData = await getAgencyMetaData(config);
+      const agenciesMetaData = await getAgencyMetaData(config, logger);
 
       const queryParams = getAgencyTerms(request);
       const searchQuery = searchTermsQuery({ queryParams, termTypesToSearch: config.TERM_TYPES_TO_SEARCH });
@@ -144,7 +144,7 @@ function getApiRoutes(config, router) {
   router.get(`/agencies/:agency_acronym`, async (request, response, next) => {
 
     try {
-      const agenciesMetaData = await getAgencyMetaData(config);
+      const agenciesMetaData = await getAgencyMetaData(config, logger);
 
       const queryParams = getAgencyTerms(request);
       const searchQuery = getQueryByTerm({ term: queryParams.term, termType: queryParams.term_type });

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -125,17 +125,14 @@ function getApiRoutes(config, router) {
         agenciesDataHash: agenciesMetaData
       };
 
-      const agencies = getAgencies(agenciesData, request.query, logger);
+      const {total, agencies} = getAgencies(agenciesData, request.query, logger);
 
-      if(agencies.total === 0) {
+      if(total === 0) {
         const error = new Error('Not Found');
         error.status = 404;
         throw error;
       }
-      response.json({
-        total: results.total,
-        agencies: results.data
-      });
+      response.json({ total, agencies });
     } catch(error) {
       logger.trace(error);
       next(error);

--- a/routes/utils.js
+++ b/routes/utils.js
@@ -213,7 +213,7 @@ function getAgencies(agenciesData, requestOptions, logger) {
 
   return {
     total: agencies.length,
-    agencies: agencies
+    agencies
   };
 }
 


### PR DESCRIPTION
**Summary**

- Add logger to getAgencyMetaData calls
- readAgencyMetadataFile refactor
  - Refactored readAgencyMetadataFile function to fetch remote metadata file or read local metadata file.
- improved error handling to avoid api crash
- Added logger to functions to better log errors as they happen
- Fixed return values.
  - Reverted to previous response schema for agencies endpoints

This PR fixes/implements the following **bugs/features**

* [x] Bug #292 

Explain the **motivation** for making this change. What existing problem does the pull request solve?

These updates were not pushed when we merged the first PR for this topic.

**Closing issues**

Closes #292 
